### PR TITLE
Add repository dispatch

### DIFF
--- a/.github/workflows/pushimge-next.yaml
+++ b/.github/workflows/pushimge-next.yaml
@@ -11,6 +11,8 @@ name: Next Dockerimage
 on:
   push:
     branches: [ master ]
+  repository_dispatch:
+    types: [build]
 
 jobs:
 
@@ -37,7 +39,7 @@ jobs:
         registry: quay.io
         username: ${{ secrets.QUAY_USERNAME }}
         password: ${{ secrets.QUAY_PASSWORD }}
-    - name: Build the registry index image
+    - name: Build the devfile-index docker image
       run: registry-support/build-tools/build.sh registry-repo/
-    - name: Push the registry index image
+    - name: Push the devfile-index docker image
       run: registry-support/build-tools/push.sh quay.io/devfile/devfile-index:next


### PR DESCRIPTION
Signed-off-by: jingfu wang <jingfwan@redhat.com>

This PR adds the repository dispatch in github CI on the receiver side.
PR to send the repository dispatch event: https://github.com/devfile/registry-support/pull/26