### PR TITLE
(Hosted Registry) Set up cicd scripts for the hosted registry

### DIFF
--- a/.ci/build.sh
+++ b/.ci/build.sh
@@ -1,0 +1,36 @@
+#
+# Copyright (c) 2021 Red Hat, Inc.
+# This program and the accompanying materials are made
+# available under the terms of the Eclipse Public License 2.0
+# which is available at https://www.eclipse.org/legal/epl-2.0/
+#
+# SPDX-License-Identifier: EPL-2.0
+#
+
+#!/usr/bin/env bash
+# This script downloads the registry build tools and builds up this repository
+# This script runs on both the GitHub action CI and the CICD for the hosted registry
+
+# cleanup_and_exit removes the registry-support folder we cloned and exits with the exit code passed into it
+ciFolder="$(dirname "$0")"
+ABSOLUTE_PATH="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+cleanup_and_exit() {
+  rm -rf $ABSOLUTE_PATH/registry-support
+  exit $1
+}
+
+cd $ciFolder
+rm -rf registry-support/
+
+# Clone the build tools
+git clone https://github.com/devfile/registry-support.git
+if [ $? -ne 0 ]; then
+  echo "Failed to clone build tools repo"
+  cleanup_and_exit 1
+fi
+
+# Run the build script
+./registry-support/build-tools/build.sh ../
+
+cleanup_and_exit 0

--- a/.ci/build_and_deploy.sh
+++ b/.ci/build_and_deploy.sh
@@ -1,0 +1,26 @@
+#
+# Copyright (c) 2021 Red Hat, Inc.
+# This program and the accompanying materials are made
+# available under the terms of the Eclipse Public License 2.0
+# which is available at https://www.eclipse.org/legal/epl-2.0/
+#
+# SPDX-License-Identifier: EPL-2.0
+#
+
+#!/usr/bin/env bash
+# This script downloads the registry build tools and builds up this repository then pushes it to quay.io
+# This will be run via the ci 
+set -ex
+ABSOLUTE_PATH="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+# Run the build script
+$ABSOLUTE_PATH/build.sh
+
+# Push the iamge to quay.io
+if [[ -n "$QUAY_USER" && -n "$QUAY_TOKEN" ]]; then
+    DOCKER_CONF="$PWD/.docker"
+    mkdir -p "$DOCKER_CONF"
+    docker tag devfile-index "${IMAGE}:${IMAGE_TAG}"
+    docker --config="$DOCKER_CONF" login -u="$QUAY_USER" -p="$QUAY_TOKEN" quay.io
+    docker --config="$DOCKER_CONF" push "${IMAGE}:${IMAGE_TAG}"
+fi


### PR DESCRIPTION
The cicd pipeline job for the hosted devfile registry requires there be scripts in this repository that can build the registry into the devfile index image and push it to quay.io/app-sre. So I've added a couple simple scripts that do the following:
1) a build.sh script that clones the registry builds tools and calls the registry build script
2) a build_and_deploy.sh script that calls the aforementioned build.sh script and pushes it up to the quay.io/app-sre repo.

Signed-off-by: John Collier <jcollier@redhat.com>