### PR TITLE
Set environment variables for pushing index image to quay

### DIFF
--- a/.ci/build_and_deploy.sh
+++ b/.ci/build_and_deploy.sh
@@ -9,9 +9,12 @@
 
 #!/usr/bin/env bash
 # This script downloads the registry build tools and builds up this repository then pushes it to quay.io
-# This will be run via the ci 
+# This will be run via the app-sre CI.
 set -ex
 ABSOLUTE_PATH="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+GIT_REV="$(git rev-parse --short=7 HEAD)"
+IMAGE="${IMAGE:-quay.io/app-sre/devfile-index}"
+IMAGE_TAG="${IMAGE_TAG:-${GIT_REV}}"
 
 # Run the build script
 $ABSOLUTE_PATH/build.sh
@@ -23,4 +26,5 @@ if [[ -n "$QUAY_USER" && -n "$QUAY_TOKEN" ]]; then
     docker tag devfile-index "${IMAGE}:${IMAGE_TAG}"
     docker --config="$DOCKER_CONF" login -u="$QUAY_USER" -p="$QUAY_TOKEN" quay.io
     docker --config="$DOCKER_CONF" push "${IMAGE}:${IMAGE_TAG}"
+    docker --config="$DOCKER_CONF" push "${IMAGE}:next"
 fi

--- a/.ci/build_and_deploy.sh
+++ b/.ci/build_and_deploy.sh
@@ -24,6 +24,7 @@ if [[ -n "$QUAY_USER" && -n "$QUAY_TOKEN" ]]; then
     DOCKER_CONF="$PWD/.docker"
     mkdir -p "$DOCKER_CONF"
     docker tag devfile-index "${IMAGE}:${IMAGE_TAG}"
+    docker tag devfile-index "${IMAGE}:next"
     docker --config="$DOCKER_CONF" login -u="$QUAY_USER" -p="$QUAY_TOKEN" quay.io
     docker --config="$DOCKER_CONF" push "${IMAGE}:${IMAGE_TAG}"
     docker --config="$DOCKER_CONF" push "${IMAGE}:next"


### PR DESCRIPTION
This PR updates the build_and_deploy.sh script that runs on the app-sre jenkins CI job to properly set the `IMAGE` and `IMAGE_TAG` variables. It also makes sure now to push to both to the given tag (corresponding to the git revision) as well as the `next` tag.