### PR TITLE
Updata java-openliberty from odo-devfiles

### DIFF
--- a/stacks/java-openliberty/devfile.yaml
+++ b/stacks/java-openliberty/devfile.yaml
@@ -1,11 +1,13 @@
 schemaVersion: 2.0.0
 metadata:
   name: java-openliberty
-  version: 0.3.0
+  version: 0.4.1
   description: Java application stack using Open Liberty runtime
   displayName: "Open Liberty"
   language: "java"
   projectType: "docker"
+  alpha.build-dockerfile: "https://github.com/OpenLiberty/application-stack/releases/download/outer-loop-0.5.0/Dockerfile"
+  alpha.deployment-manifest: "https://github.com/OpenLiberty/application-stack/releases/download/outer-loop-0.5.0/app-deploy.yaml"
 starterProjects:
   - name: user-app
     git:


### PR DESCRIPTION
The java-openliberty devfile was updated on the odo-devfiles/registry repo shortly after the last registry sync that I did, so I'm just updating it here.