### PR TITLE
Update readme for hosted registry

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # registry
-Devfile registry - storing contents of the common devfile registry that feeds into the OCI based common registry
+Devfile registry - storing contents of the common devfile registry that feeds into the OCI based common registry.
+
+The devfiles in this repository feed into the publicly hosted devfile registry at https://registry.devfile.io. 
 
 ## Build
 
@@ -9,4 +11,10 @@ To build this devfile registry into a container image:
 2. cd into `registry-support/build-tools`
 3. Run `build.sh <path-to-this-repository-on-disk>`
 
-From there, push the container image to a container registry of your choice.
+From there, push the container image to a container registry of your choice and deploy using one of the methods outlined [here](https://github.com/devfile/registry-support#deploy).
+
+## Reporting any issue
+
+For issues relating to a specific devfile stack in this repository, please reach out to the devfile stack maintainer to determine where to open an issue.
+
+For issues relating to the hosted devfile registry service (https://registry.devfile.io), or devfile registries in general, please use the [devfile/api](github.com/devfile/api/) issue tracker for opening issues related to the devfile registry. Apply the `area/registry` label for registry issues for better visibility.


### PR DESCRIPTION
Updates the repository's readme to mention the hosted devfile registry service and also adds a note at the bottom for opening issues.