### PR TITLE
Add extraDevfileEntires.yaml to support sample

### DIFF
--- a/extraDevfileEntries.yaml
+++ b/extraDevfileEntries.yaml
@@ -4,7 +4,7 @@ samples:
     displayName: Basic NodeJS
     description: A simple Hello World application
     icon: nodejsIcon.svg
-    tags: ["NodeJS", “Express”]
+    tags: ["NodeJS", "Express"]
     git:
       remotes:
         origin: https://github.com/redhat-developer/devfile-sample

--- a/extraDevfileEntries.yaml
+++ b/extraDevfileEntries.yaml
@@ -1,0 +1,18 @@
+schemaVersion: 1.0.0
+samples:
+  - name: nodejs-basic
+    displayName: Basic NodeJS
+    description: A simple Hello World application
+    icon: nodejsIcon.svg
+    tags: ["NodeJS", “Express”]
+    git:
+      remotes:
+        origin: https://github.com/redhat-developer/devfile-sample
+  - name: vertx-secured-http
+    displayName: Vert.x with secured HTTP
+    description: A Vert.x application using secured HTTP
+    icon: vertxIcon.svg
+    tags: ["Java", "Vert.x"]
+    git:
+      remotes:
+        origin: https://github.com/openshift-vertx-examples/vertx-secured-http-example-redhat

--- a/extraDevfileEntries.yaml
+++ b/extraDevfileEntries.yaml
@@ -5,6 +5,8 @@ samples:
     description: A simple Hello World application
     icon: nodejsIcon.svg
     tags: ["NodeJS", "Express"]
+    projectType: nodejs
+    language: nodejs
     git:
       remotes:
         origin: https://github.com/redhat-developer/devfile-sample
@@ -13,6 +15,8 @@ samples:
     description: A Vert.x application using secured HTTP
     icon: vertxIcon.svg
     tags: ["Java", "Vert.x"]
+    projectType: vertx
+    language: java
     git:
       remotes:
         origin: https://github.com/openshift-vertx-examples/vertx-secured-http-example-redhat


### PR DESCRIPTION
This PR adds extraDevfileEntires.yaml to support sample according to the proposal: https://docs.google.com/document/d/1tbzZK9aWtpw5AtoZmUl1Jy8x8w9N5hhjXu3c26VYiYY/edit#heading=h.6w072oor8mro

Signed-off-by: jingfu wang <jingfwan@redhat.com>