### PR TITLE
Hard code scripts to specific commit of build tools

### DIFF
--- a/.ci/build.sh
+++ b/.ci/build.sh
@@ -29,6 +29,7 @@ if [ $? -ne 0 ]; then
   echo "Failed to clone build tools repo"
   cleanup_and_exit 1
 fi
+git checkout cd279527f87340d6b51ee366e70140ecfceef960
 
 # Run the build script
 ./registry-support/build-tools/build.sh ../


### PR DESCRIPTION
I'm going to be delivering some breaking changes to the build tools in https://github.com/devfile/registry-support/tree/master/build-tools and I don't want to break the scripts in this repository that depend on them, so hardcoding to a specific commit in the meanwhile.