### PR TITLE
Fix GitHub actions for updated build tools

### DIFF
--- a/.ci/build.sh
+++ b/.ci/build.sh
@@ -29,7 +29,7 @@ if [ $? -ne 0 ]; then
   echo "Failed to clone build tools repo"
   cleanup_and_exit 1
 fi
-git checkout cd279527f87340d6b51ee366e70140ecfceef960
+git checkout 17fe1800832a85533438225705644fbc4c41fb79
 
 # Run the build script
 ./registry-support/build-tools/build.sh ../

--- a/.ci/build.sh
+++ b/.ci/build.sh
@@ -29,8 +29,9 @@ if [ $? -ne 0 ]; then
   echo "Failed to clone build tools repo"
   cleanup_and_exit 1
 fi
+git checkout cd279527f87340d6b51ee366e70140ecfceef960
 
 # Run the build script
-./registry-support/build-tools/build_image.sh ../
+./registry-support/build-tools/build.sh ../
 
 cleanup_and_exit 0

--- a/.ci/build.sh
+++ b/.ci/build.sh
@@ -29,9 +29,8 @@ if [ $? -ne 0 ]; then
   echo "Failed to clone build tools repo"
   cleanup_and_exit 1
 fi
-git checkout cd279527f87340d6b51ee366e70140ecfceef960
 
 # Run the build script
-./registry-support/build-tools/build.sh ../
+./registry-support/build-tools/build_image.sh ../
 
 cleanup_and_exit 0

--- a/.ci/build.sh
+++ b/.ci/build.sh
@@ -29,7 +29,7 @@ if [ $? -ne 0 ]; then
   echo "Failed to clone build tools repo"
   cleanup_and_exit 1
 fi
-git checkout 17fe1800832a85533438225705644fbc4c41fb79
+cd registry-support && git checkout cd279527f87340d6b51ee366e70140ecfceef960 && cd ..
 
 # Run the build script
 ./registry-support/build-tools/build.sh ../

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -37,4 +37,4 @@ jobs:
         go-version: 1.13
     
     - name: Check if devfile registry build is working
-      run: chmod +x registry-support/build-tools/build_image.sh && registry-support/build-tools/build_image.sh registry-repo/
+      run: registry-support/build-tools/build_image.sh registry-repo/

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -37,4 +37,4 @@ jobs:
         go-version: 1.13
     
     - name: Check if devfile registry build is working
-      run: registry-support/build-tools/build_image.sh registry-repo/
+      run: chmod +x registry-support/build-tools/build_image.sh && registry-support/build-tools/build_image.sh registry-repo/

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -37,4 +37,4 @@ jobs:
         go-version: 1.13
     
     - name: Check if devfile registry build is working
-      run: registry-support/build-tools/build_image.sh registry-repo/
+      run: registry-repo/.ci/build.sh

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -37,4 +37,4 @@ jobs:
         go-version: 1.13
     
     - name: Check if devfile registry build is working
-      run: registry-support/build-tools/build.sh registry-repo/
+      run: registry-support/build-tools/build_image.sh registry-repo/

--- a/.github/workflows/pushimge-next.yaml
+++ b/.github/workflows/pushimge-next.yaml
@@ -40,6 +40,6 @@ jobs:
         username: ${{ secrets.QUAY_USERNAME }}
         password: ${{ secrets.QUAY_PASSWORD }}
     - name: Build the devfile-index docker image
-      run: registry-support/build-tools/build.sh registry-repo/
+      run: registry-support/build-tools/build_image.sh registry-repo/
     - name: Push the devfile-index docker image
       run: registry-support/build-tools/push.sh quay.io/devfile/devfile-index:next

--- a/.github/workflows/pushimge-next.yaml
+++ b/.github/workflows/pushimge-next.yaml
@@ -40,6 +40,6 @@ jobs:
         username: ${{ secrets.QUAY_USERNAME }}
         password: ${{ secrets.QUAY_PASSWORD }}
     - name: Build the devfile-index docker image
-      run: chmod +x registry-support/build-tools/build_image.sh && registry-support/build-tools/build_image.sh registry-repo/
+      run: registry-support/build-tools/build_image.sh registry-repo/
     - name: Push the devfile-index docker image
       run: registry-support/build-tools/push.sh quay.io/devfile/devfile-index:next

--- a/.github/workflows/pushimge-next.yaml
+++ b/.github/workflows/pushimge-next.yaml
@@ -40,6 +40,6 @@ jobs:
         username: ${{ secrets.QUAY_USERNAME }}
         password: ${{ secrets.QUAY_PASSWORD }}
     - name: Build the devfile-index docker image
-      run: registry-support/build-tools/build_image.sh registry-repo/
+      run: registry-repo/.ci/build.sh
     - name: Push the devfile-index docker image
       run: registry-support/build-tools/push.sh quay.io/devfile/devfile-index:next

--- a/.github/workflows/pushimge-next.yaml
+++ b/.github/workflows/pushimge-next.yaml
@@ -40,6 +40,6 @@ jobs:
         username: ${{ secrets.QUAY_USERNAME }}
         password: ${{ secrets.QUAY_PASSWORD }}
     - name: Build the devfile-index docker image
-      run: registry-support/build-tools/build_image.sh registry-repo/
+      run: chmod +x registry-support/build-tools/build_image.sh && registry-support/build-tools/build_image.sh registry-repo/
     - name: Push the devfile-index docker image
       run: registry-support/build-tools/push.sh quay.io/devfile/devfile-index:next


### PR DESCRIPTION
We should be calling `build_image.sh` in the Github actions for this repo now rather than `build.sh`