### PR TITLE
Use quay.io alpine-go image for registry build layer

### DIFF
--- a/.ci/Dockerfile
+++ b/.ci/Dockerfile
@@ -6,7 +6,7 @@
 #
 # SPDX-License-Identifier: EPL-2.0
 #
-FROM quay.io/openshift-pipeline/golang:1.15 AS builder
+FROM quay.io/openshift-pipeline/golang:1.15-alpine AS builder
 
 # Install dependencies
 RUN apk add --no-cache git bash

--- a/.ci/Dockerfile
+++ b/.ci/Dockerfile
@@ -6,7 +6,7 @@
 #
 # SPDX-License-Identifier: EPL-2.0
 #
-FROM golang:alpine3.11 AS builder
+FROM quay.io/openshift-pipeline/golang:1.15 AS builder
 
 # Install dependencies
 RUN apk add --no-cache git bash


### PR DESCRIPTION
AppSRE's ci-int pipelines requires the images used in Dockerfiles to be in quay.io, so moving to an alpine-go base image hosted on quay.