### PR TITLE
Update CI test script to use local preferences file

### DIFF
--- a/.ci/openshift_integration.sh
+++ b/.ci/openshift_integration.sh
@@ -30,6 +30,8 @@ git clone https://github.com/openshift/odo.git
 cd odo && make
 cd ..
 
+export GLOBALODOCONFIG=$(pwd)/preferences.yaml
+
 # Install the devfile registry
 git clone https://github.com/devfile/registry-support.git
 oc process -f registry-support/deploy/hosted-registry/devfile-registry.yaml -p DEVFILE_INDEX_IMAGE=$IMG -p DEVFILE_INDEX_IMAGE_TAG=$TAG -p REPLICAS=3 | \


### PR DESCRIPTION
Looks like permissions in the CI test container isn't sufficient to use the default odo preferences file, so need to override the location.