### PR TITLE
Remove dockerignore file for extraDevfilesEntry

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,2 +1,0 @@
-# Ignore the extraDevfileEntries.yaml file until the devfile registry library can support filtering stacks and samples
-extraDevfileEntries.yaml


### PR DESCRIPTION
The index server's endpoints now properly supports samples, so we can update the registry to remove the .dockerignore file that was preventing the extraDevfilesEntry yaml file from being included in the registry build