### PR TITLE
sample: point to new Node.js DevFile sample

### DIFF
--- a/extraDevfileEntries.yaml
+++ b/extraDevfileEntries.yaml
@@ -1,7 +1,7 @@
 schemaVersion: 1.0.0
 samples:
   - name: nodejs-basic
-    displayName: Basic NodeJS
+    displayName: Basic Node.js
     description: A simple Hello World Node.js application
     icon: https://raw.githubusercontent.com/maysunfaisal/node-bulletin-board-2/main/nodejs-icon.png
     tags: ["NodeJS", "Express"]
@@ -9,7 +9,7 @@ samples:
     language: nodejs
     git:
       remotes:
-        origin: https://github.com/redhat-developer/devfile-sample.git
+        origin: https://github.com/nodeshift-starters/devfile-sample.git
   - name: code-with-quarkus
     displayName: Basic Quarkus
     description: A simple Hello World Java application using Quarkus


### PR DESCRIPTION
I've created a Node.js DevFile Sample that the Node.js team will maintain at https://github.com/nodeshift-starters/devfile-sample. We'd like to control the content of the Node.js sample so it can be aligned with our [reference architecture for Node.js](https://github.com/nodeshift/nodejs-reference-architecture).

I do not know how to test that the DevFile Sample we've created conforms to the expected specification to enable it to be shown as a sample in the DevFile UI. I tried to infer what was necessary from https://github.com/redhat-developer/devfile-sample (e.g. `Dockerfile`, and `alpha.build-dockerfile: Dockerfile` attributes in the DevFile).

- https://github.com/nodeshift-starters/devfile-sample/blob/main/devfile.yaml
- https://github.com/nodeshift-starters/devfile-sample/blob/main/Dockerfile

Please review/let me know how I can test this. 