### PR TITLE
Migrate devfile-registry acceptance tests

### DIFF
--- a/.ci/acceptance-tests/devfile-registry-acceptance.yaml
+++ b/.ci/acceptance-tests/devfile-registry-acceptance.yaml
@@ -1,0 +1,34 @@
+---
+apiVersion: v1
+kind: Template
+metadata:
+  name: devfile-registry-acceptance
+objects:
+- apiVersion: batch/v1
+  kind: Job
+  metadata:
+    name: devfile-registry-acceptance-${JOB_NAME}
+  spec:
+    backoffLimit: 5
+    template:
+      spec:
+        restartPolicy: Never
+        containers:
+          - image: ${IMAGE}:${IMAGE_TAG}
+            imagePullPolicy: Always
+            name: github-mirror-acceptance
+            env:
+              - name: REGISTRY
+                value: ${REGISTRY}
+parameters:
+- name: IMAGE
+  value: quay.io/devfile/devfile-registry-integration
+- name: IMAGE_TAG
+  value: "next"
+  required: true
+- name: REGISTRY
+  value: "https://registry.stage.devfile.io"
+  required: true
+- name: JOB_NAME
+  generate: expression
+  from: "[a-z0-9]{5}"


### PR DESCRIPTION
Migrates the acceptance tests templates from registry-support to this repository as AppSRE requires it to be in this repo.