### PR TITLE
Migrate openshift template for registry

### DIFF
--- a/.ci/deploy/devfile-registry.yaml
+++ b/.ci/deploy/devfile-registry.yaml
@@ -1,0 +1,187 @@
+#
+# Copyright (c) 2021 Red Hat, Inc.
+# This program and the accompanying materials are made
+# available under the terms of the Eclipse Public License 2.0
+# which is available at https://www.eclipse.org/legal/epl-2.0/
+#
+# SPDX-License-Identifier: EPL-2.0
+#
+---
+apiVersion: v1
+kind: Template
+metadata:
+  name: devfile-registry
+objects:
+- apiVersion: apps/v1
+  kind: Deployment
+  metadata:
+    labels:
+      app: devfile-registry
+    name: devfile-registry
+  spec:
+    replicas: ${{REPLICAS}}
+    selector:
+      matchLabels:
+        app: devfile-registry
+    strategy:
+      type: RollingUpdate
+      rollingUpdate:
+        maxSurge: 25%
+        maxUnavailable: 25%
+    template:
+      metadata:
+        labels:
+          app: devfile-registry
+      spec:
+        volumes:
+          - name: devfile-registry-storage
+            emptyDir: {}
+          - name: config
+            configMap:
+              name: devfile-registry
+              items:
+                - key: registry-config.yml
+                  path: config.yml
+        containers:
+        - image: ${DEVFILE_INDEX_IMAGE}:${DEVFILE_INDEX_IMAGE_TAG}
+          imagePullPolicy: "${DEVFILE_INDEX_PULL_POLICY}"
+          name: devfile-registry
+          ports:
+          - containerPort: 8080
+          livenessProbe:
+            httpGet:
+              path: /
+              port: 8080
+            initialDelaySeconds: 30
+            periodSeconds: 10
+            timeoutSeconds: 3
+          readinessProbe:
+            httpGet:
+              path: /
+              port: 8080
+            initialDelaySeconds: 3
+            periodSeconds: 10
+            timeoutSeconds: 3
+          resources:
+            requests:
+              cpu: 1m
+              memory: 5Mi
+            limits:
+              cpu: 100m
+              memory: ${DEVFILE_INDEX_MEMORY_LIMIT}
+        - image: ${OCI_REGISTRY_IMAGE}:${OCI_REGISTRY_IMAGE_TAG}
+          imagePullPolicy: "${OCI_REGISTRY_PULL_POLICY}"
+          name: oci-registry
+          livenessProbe:
+            httpGet:
+              path: /v2/
+              port: 5000
+            initialDelaySeconds: 30
+            periodSeconds: 10
+            timeoutSeconds: 3
+          readinessProbe:
+            httpGet:
+              path: /v2/
+              port: 5000
+            initialDelaySeconds: 3
+            periodSeconds: 10
+            timeoutSeconds: 3
+          resources:
+            requests:
+              cpu: 1m
+              memory: 5Mi
+            limits:
+              cpu: 100m
+              memory: ${OCI_REGISTRY_MEMORY_LIMIT}
+          volumeMounts:
+          - name: devfile-registry-storage
+            mountPath: "/var/lib/registry"
+          - name: config
+            mountPath: "/etc/docker/registry"
+            readOnly: true
+- apiVersion: v1
+  kind: Service
+  metadata:
+    name: devfile-registry
+    labels:
+      app: devfile-registry
+  spec:
+    ports:
+      - name: http
+        protocol: TCP
+        port: 8080
+        targetPort: 8080
+      - name: oci-metrics
+        protocol: TCP
+        port: 5001
+        targetPort: 5001
+      - name: index-metrics
+        protocol: TCP
+        port: 7071
+        targetPort: 7071
+    selector:
+      app: devfile-registry
+- apiVersion: v1
+  kind: ConfigMap
+  metadata:
+    name: devfile-registry
+    annotations:
+      qontract.recycle: "true"
+  data:
+    registry-config.yml: |
+      version: 0.1
+      log:
+        fields:
+          service: registry
+      storage:
+        cache:
+          blobdescriptor: inmemory
+        filesystem:
+          rootdirectory: /var/lib/registry
+      http:
+        addr: :5000
+        headers:
+          X-Content-Type-Options: [nosniff]
+        debug:
+          addr: :5001
+          prometheus:
+            enabled: true
+            path: /metrics
+
+parameters:
+- name: DEVFILE_INDEX_IMAGE
+  value: quay.io/devfile/devfile-index
+  displayName: Devfile registry index image
+  description: Devfile registry index docker image. Defaults to quay.io/devfile/devfile-index
+- name: DEVFILE_INDEX_IMAGE_TAG
+  value: next
+  displayName: Devfile registry version
+  description: Devfile registry version which defaults to next
+- name: DEVFILE_INDEX_MEMORY_LIMIT
+  value: 256Mi
+  displayName: Memory Limit
+  description: Maximum amount of memory the container can use. Defaults 256Mi
+- name: DEVFILE_INDEX_PULL_POLICY
+  value: Always
+  displayName: Devfile registry image pull policy
+  description: Always pull by default. Can be IfNotPresent
+- name: OCI_REGISTRY_IMAGE
+  value: quay.io/devfile/oci-registry
+  displayName: OCI registry index image
+  description: OCI registry index docker image. Defaults to quay.io/devfile/devfile-index
+- name: OCI_REGISTRY_IMAGE_TAG
+  value: next
+  displayName: OCI registry version
+  description: OCI registry version which defaults to next
+- name: OCI_REGISTRY_MEMORY_LIMIT
+  value: 256Mi
+  displayName: Memory Limit
+  description: Maximum amount of memory the OCI registry container can use. Defaults 256Mi
+- name: OCI_REGISTRY_PULL_POLICY
+  value: Always
+  displayName: Devfile registry image pull policy
+  description: Always pull by default. Can be IfNotPresent
+- name: REPLICAS
+  value: "1"
+  displayName: Devfile registry replicas
+  description: The number of replicas for the hosted devfile registry service


### PR DESCRIPTION
AppSRE's tekton based pipelines now require that the OpenShift templates for the devfile registry be hosted in this repository, so migrating the OpenShift template from registry-support to this repo.