### PR TITLE
Disable layer caching on image build for registry

### DIFF
--- a/.ci/build.sh
+++ b/.ci/build.sh
@@ -13,4 +13,4 @@
 
 ABSOLUTE_PATH="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 
-docker build -t devfile-index -f $ABSOLUTE_PATH/Dockerfile $ABSOLUTE_PATH/..
+docker build --no-cache -t devfile-index -f $ABSOLUTE_PATH/Dockerfile $ABSOLUTE_PATH/..


### PR DESCRIPTION
The Jenkins build for the registry on AppSRE seems to be stuck using a cached version of the devfile index base image, so adding this flag to disable it.