### PR TITLE
Update Minikube action to newer version

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -19,14 +19,6 @@ jobs:
     name: Check registry build
     runs-on: ubuntu-latest
     steps:
-    - name: Checkout registry build tools
-      uses: actions/checkout@v2
-      with:
-        repository: devfile/registry-support
-        persist-credentials: false
-        path: registry-support
-
-    
     - name: Check out code
       uses: actions/checkout@v2
       with:

--- a/.github/workflows/validate-devfiles-minikube.yaml
+++ b/.github/workflows/validate-devfiles-minikube.yaml
@@ -23,13 +23,13 @@ jobs:
     - name: Checkout
       uses: actions/checkout@v1
     - name: Setup Minikube
-      uses: manusa/actions-setup-minikube@v2.3.1
+      uses: manusa/actions-setup-minikube@v2.4.2
       with:
-        minikube version: 'v1.16.0'
-        kubernetes version: 'v1.19.2'
+        minikube version: 'v1.21.0'
+        kubernetes version: 'v1.21.0'
         driver: 'docker'
-    - name: Enable ingress on Minikube
-      run: minikube addons enable ingress
+        github token: ${{ secrets.GITHUB_TOKEN }}
+        start args: '--addons=ingress'
     - name: Install CLI tools
       uses: redhat-actions/openshift-tools-installer@v1
       with:


### PR DESCRIPTION
Fixes https://github.com/devfile/api/issues/525

- Updates the registry test action to use an updated version of `manusa/actions-setup-minikube`, as well as a newer version of Kubernetes.
- Removes an unnecessary checkout of the registry-support repo during the CI build, it's no longer needed.