### PR TITLE
Add icons for springboot, python, python-django

### DIFF
--- a/stacks/java-springboot/devfile.yaml
+++ b/stacks/java-springboot/devfile.yaml
@@ -6,7 +6,7 @@ metadata:
   description: Spring Boot® using Java
   tags: ["Java", "Spring"]
   globalMemoryLimit: 2674Mi
-  icon: https://www.eclipse.org/che/images/logo-eclipseche.svg
+  icon: https://spring.io/images/projects/spring-edf462fec682b9d48cf628eaf9e19521.svg
   projectType: "spring"
   language: "java"
 starterProjects:

--- a/stacks/python-django/devfile.yaml
+++ b/stacks/python-django/devfile.yaml
@@ -4,6 +4,7 @@ metadata:
   version: 1.0.0
   displayName: Django
   description: Python3.7 with Django
+  icon: https://static.djangoproject.com/img/logos/django-logo-positive.svg
   tags: ["Python", "pip", "Django"]
   projectType: "django"
   language: "python"

--- a/stacks/python/devfile.yaml
+++ b/stacks/python/devfile.yaml
@@ -4,6 +4,7 @@ metadata:
   version: 1.0.0
   displayName: Python
   description: Python Stack with Python 3.7
+  icon: https://www.python.org/static/community_logos/python-logo-generic.svg
   tags: ["Python", "pip"]
   projectType: "python"
   language: "python"


### PR DESCRIPTION
Adds icons for the following stacks:
- `java-springboot`: https://spring.io/images/projects/spring-edf462fec682b9d48cf628eaf9e19521.svg
- `python`: https://www.python.org/static/community_logos/python-logo-generic.svg
- `python-django`: https://static.djangoproject.com/img/logos/django-logo-positive.svg