### PR TITLE
Add icon for Open Liberty

### DIFF
--- a/stacks/java-openliberty/devfile.yaml
+++ b/stacks/java-openliberty/devfile.yaml
@@ -20,6 +20,7 @@ metadata:
   version: 0.5.0
   displayName: "Open Liberty"
   description: Java application stack using Open Liberty runtime
+  icon: https://raw.githubusercontent.com/OpenLiberty/logos/7fbb132949b9b2589e18c8d5665c1b107028a21d/logomark/svg/OL_logomark.svg
   tags: ["Java", "Maven"]
   language: "java"
   projectType: "openliberty"


### PR DESCRIPTION
Adds an icon for the java-openliberty stack:

<img width="452" alt="Screen Shot 2021-08-03 at 1 30 02 PM" src="https://user-images.githubusercontent.com/6880023/128059885-8e9432ee-a0e1-4482-b91e-2fcf91829c6c.png">

Sourced from https://raw.githubusercontent.com/OpenLiberty/logos/7fbb132949b9b2589e18c8d5665c1b107028a21d/logomark/svg/OL_logomark.svg

@scottkurz @mezarin Let me know if this is the right icon to use or if another should be used.