### PR TITLE
Add icon for java-vertx stack

### DIFF
--- a/stacks/java-vertx/devfile.yaml
+++ b/stacks/java-vertx/devfile.yaml
@@ -4,6 +4,7 @@ metadata:
   version: 1.1.0
   displayName: Vert.x Java
   description: Upstream Vert.x using Java
+  icon: https://raw.githubusercontent.com/vertx-web-site/vertx-logo/master/vertx-logo.svg
   tags: ["Java", "Vert.x"]
   projectType: "vertx"
   language: "java"


### PR DESCRIPTION
Adds an icon for the java-vertx stack:

<img width="974" alt="Screen Shot 2021-08-03 at 1 36 15 PM" src="https://user-images.githubusercontent.com/6880023/128060721-90cf0d1e-7a2a-488c-8506-cd8319f6d7f0.png">

Sourced from: https://github.com/vertx-web-site/vertx-logo/blob/master/vertx-logo.svg