### PR TITLE
Add icon for java-quarkus stack

### DIFF
--- a/stacks/java-quarkus/devfile.yaml
+++ b/stacks/java-quarkus/devfile.yaml
@@ -5,6 +5,7 @@ metadata:
   website: https://quarkus.io
   displayName: Quarkus Java
   description: Quarkus with Java
+  icon: https://design.jboss.org/quarkus/logo/final/SVG/quarkus_icon_rgb_default.svg
   tags: ["Java", "Quarkus"]
   projectType: "quarkus"
   language: "java"


### PR DESCRIPTION
Adds an icon for the java-quarkus stack:
<img width="650" alt="Screen Shot 2021-08-03 at 1 40 49 PM" src="https://user-images.githubusercontent.com/6880023/128061249-e118d1fa-721d-4795-81db-6f2e67af8020.png">

Sourced from: https://design.jboss.org/quarkus/logo/final/SVG/quarkus_icon_rgb_default.svg