### PR TITLE
Add icons for wildfly stacks

### DIFF
--- a/stacks/java-wildfly-bootable-jar/devfile.yaml
+++ b/stacks/java-wildfly-bootable-jar/devfile.yaml
@@ -5,6 +5,7 @@ metadata:
   website: https://docs.wildfly.org/bootablejar/
   displayName: WildFly Bootable Jar
   description: Java stack with WildFly in bootable Jar mode, OpenJDK 11 and Maven 3.5
+  icon: https://design.jboss.org/wildfly/logo/final/wildfly_logomark.svg
   tags:  ["RHEL8", "Java", "OpenJDK", "Maven", "WildFly", "Microprofile", "WildFly Bootable"]
   projectType: "WildFly"
   language: "java"

--- a/stacks/java-wildfly/devfile.yaml
+++ b/stacks/java-wildfly/devfile.yaml
@@ -5,6 +5,7 @@ metadata:
   website: https://wildfly.org
   displayName: WildFly Java
   description: Upstream WildFly
+  icon: https://design.jboss.org/wildfly/logo/final/wildfly_logomark.svg
   tags: ["Java", "WildFly"]
   projectType: "wildfly"
   language: "java"


### PR DESCRIPTION
Adds icons for the two wildfly stacks (java-wildfly and java-wildfly-bootable-jar):

<img width="279" alt="Screen Shot 2021-08-03 at 1 45 06 PM" src="https://user-images.githubusercontent.com/6880023/128061786-de5ccec1-54ba-454c-b80d-b987769476c6.png">

Sourced from: https://design.jboss.org/wildfly/logo/final/wildfly_logomark.svg