### PR TITLE
Add icon for nodejs stack

### DIFF
--- a/stacks/nodejs/devfile.yaml
+++ b/stacks/nodejs/devfile.yaml
@@ -4,6 +4,7 @@ metadata:
   version: 1.0.1
   displayName: Node.js Runtime
   description: Stack with Node.js 14
+  icon: https://nodejs.org/static/images/logos/nodejs-new-pantone-black.svg
   tags: ["NodeJS", "Express", "ubi8"]
   projectType: "nodejs"
   language: "nodejs"


### PR DESCRIPTION
Adds an icon for the nodejs stack:
<img width="441" alt="Screen Shot 2021-08-03 at 1 47 29 PM" src="https://user-images.githubusercontent.com/6880023/128062138-61088d6a-7e01-4444-9ec0-c7862512940d.png">

Sourced from https://nodejs.org/static/images/logos/nodejs-new-pantone-black.svg