### PR TITLE
Use svg icons for samples

### DIFF
--- a/extraDevfileEntries.yaml
+++ b/extraDevfileEntries.yaml
@@ -3,7 +3,7 @@ samples:
   - name: nodejs-basic
     displayName: Basic Node.js
     description: A simple Hello World Node.js application
-    icon: https://raw.githubusercontent.com/maysunfaisal/node-bulletin-board-2/main/nodejs-icon.png
+    icon: https://nodejs.org/static/images/logos/nodejs-new-pantone-black.svg
     tags: ["NodeJS", "Express"]
     projectType: nodejs
     language: nodejs
@@ -13,7 +13,7 @@ samples:
   - name: code-with-quarkus
     displayName: Basic Quarkus
     description: A simple Hello World Java application using Quarkus
-    icon: https://raw.githubusercontent.com/elsony/devfile-sample-code-with-quarkus/main/.devfile/icon/quarkus.png
+    icon: https://design.jboss.org/quarkus/logo/final/SVG/quarkus_icon_rgb_default.svg
     tags: ["Java", "Quarkus"]
     projectType: quarkus
     language: java
@@ -23,7 +23,7 @@ samples:
   - name: java-springboot-basic
     displayName: Basic Spring Boot
     description: A simple Hello World Java Spring Boot application using Maven
-    icon: https://raw.githubusercontent.com/elsony/devfile-sample-java-springboot-basic/main/.devfile/icon/spring-logo.png
+    icon: https://spring.io/images/projects/spring-edf462fec682b9d48cf628eaf9e19521.svg
     tags: ["Java", "Spring"]
     projectType: springboot
     language: java
@@ -33,7 +33,7 @@ samples:
   - name: python-basic
     displayName: Basic Python
     description: A simple Hello World application using Python
-    icon: https://raw.githubusercontent.com/elsony/devfile-sample-python-basic/main/.devfile/icon/python.png
+    icon: https://www.python.org/static/community_logos/python-logo-generic.svg
     tags: ["Python"]
     projectType: python
     language: python


### PR DESCRIPTION
Uses the same svg icons for samples that we used for their equivalent stacks (nodejs, quarkus, java-springboot, python)