### PR TITLE
Use IMAGE_TAG instead of DEVFILE_INDEX_IMAGE_TAG for parameter

### DIFF
--- a/.ci/deploy/devfile-registry.yaml
+++ b/.ci/deploy/devfile-registry.yaml
@@ -49,7 +49,7 @@ objects:
                 - key: devfile-registry-hosts.json
                   path: devfile-registry-hosts.json
         containers:
-        - image: ${DEVFILE_INDEX_IMAGE}:${DEVFILE_INDEX_IMAGE_TAG}
+        - image: ${IMAGE}:${IMAGE_TAG}
           imagePullPolicy: "${DEVFILE_INDEX_PULL_POLICY}"
           name: devfile-registry
           ports:
@@ -189,6 +189,14 @@ parameters:
   displayName: Devfile registry index image
   description: Devfile registry index docker image. Defaults to quay.io/devfile/devfile-index
 - name: DEVFILE_INDEX_IMAGE_TAG
+  value: next
+  displayName: Devfile registry version
+  description: Devfile registry version which defaults to next
+- name: IMAGE
+  value: quay.io/devfile/devfile-index
+  displayName: Devfile registry index image
+  description: Devfile registry index docker image. Defaults to quay.io/devfile/devfile-index
+- name: IMAGE_TAG
   value: next
   displayName: Devfile registry version
   description: Devfile registry version which defaults to next

--- a/.ci/deploy/devfile-registry.yaml
+++ b/.ci/deploy/devfile-registry.yaml
@@ -49,7 +49,7 @@ objects:
                 - key: devfile-registry-hosts.json
                   path: devfile-registry-hosts.json
         containers:
-        - image: ${IMAGE}:${IMAGE_TAG}
+        - image: ${DEVFILE_INDEX_IMAGE}:${IMAGE_TAG}
           imagePullPolicy: "${DEVFILE_INDEX_PULL_POLICY}"
           name: devfile-registry
           ports:
@@ -192,10 +192,6 @@ parameters:
   value: next
   displayName: Devfile registry version
   description: Devfile registry version which defaults to next
-- name: IMAGE
-  value: quay.io/devfile/devfile-index
-  displayName: Devfile registry index image
-  description: Devfile registry index docker image. Defaults to quay.io/devfile/devfile-index
 - name: IMAGE_TAG
   value: next
   displayName: Devfile registry version

--- a/.ci/openshift_integration.sh
+++ b/.ci/openshift_integration.sh
@@ -36,7 +36,7 @@ cd ..
 export GLOBALODOCONFIG=$(pwd)/preferences.yaml
 
 # Install the devfile registry
-oc process -f .ci/deploy/devfile-registry.yaml -p DEVFILE_INDEX_IMAGE=$IMG -p DEVFILE_INDEX_IMAGE_TAG=$TAG -p REPLICAS=3 | \
+oc process -f .ci/deploy/devfile-registry.yaml -p IMAGE=$IMG -p IMAGE_TAG=$TAG -p REPLICAS=3 | \
   oc apply -f -
 
 # Deploy the routes for the registry

--- a/.ci/openshift_integration.sh
+++ b/.ci/openshift_integration.sh
@@ -36,7 +36,7 @@ cd ..
 export GLOBALODOCONFIG=$(pwd)/preferences.yaml
 
 # Install the devfile registry
-oc process -f .ci/deploy/devfile-registry.yaml -p IMAGE=$IMG -p IMAGE_TAG=$TAG -p REPLICAS=3 | \
+oc process -f .ci/deploy/devfile-registry.yaml -p DEVFILE_INDEX_IMAGE_TAG=$IMG -p IMAGE_TAG=$TAG -p REPLICAS=3 | \
   oc apply -f -
 
 # Deploy the routes for the registry

--- a/.ci/openshift_integration.sh
+++ b/.ci/openshift_integration.sh
@@ -36,7 +36,7 @@ cd ..
 export GLOBALODOCONFIG=$(pwd)/preferences.yaml
 
 # Install the devfile registry
-oc process -f .ci/deploy/devfile-registry.yaml -p DEVFILE_INDEX_IMAGE_TAG=$IMG -p IMAGE_TAG=$TAG -p REPLICAS=3 | \
+oc process -f .ci/deploy/devfile-registry.yaml -p DEVFILE_INDEX_IMAGE=$IMG -p IMAGE_TAG=$TAG -p REPLICAS=3 | \
   oc apply -f -
 
 # Deploy the routes for the registry


### PR DESCRIPTION
AppSRE's tekton pipelines need to use IMAGE_TAG for the registry's openshift template.

I'm leaving in the old parameter until I update the saas-file in app interface to not mention the parameter.