### PR TITLE
Use persist-credentials: false in deploy trigger

### DIFF
--- a/.github/workflows/trigger-redeploy.yaml
+++ b/.github/workflows/trigger-redeploy.yaml
@@ -19,7 +19,9 @@ jobs:
     steps:
     - name: Check out code
       uses: actions/checkout@v2
-    
+      with:
+        persist-credentials: false
+
     - name: Trigger Deploy to Staging
       run: |
         git config --global user.email "${{secrets.CI_ROBOT_EMAIL}}"


### PR DESCRIPTION
Need to set `persist-credentials: false` in order to be able to make the dummy commit when dispatches are received.