### PR TITLE
Update tests for new odo version

### DIFF
--- a/.ci/openshift_integration.sh
+++ b/.ci/openshift_integration.sh
@@ -28,6 +28,9 @@ TAG="$(echo $REGISTRY_IMAGE | cut -d':' -f2)"
 # Create a project/namespace for running the tests in
 oc new-project devfile-registry-test
 
+# Install yq
+curl -sL -O https://github.com/mikefarah/yq/releases/download/v4.9.5/yq_linux_amd64 -o /usr/local/bin/yq && mv ./yq_linux_amd64 /usr/local/bin/yq && chmod +x /usr/local/bin/yq
+
 # Build odo
 git clone https://github.com/openshift/odo.git
 cd odo && make

--- a/tests/test.sh
+++ b/tests/test.sh
@@ -57,7 +57,7 @@ test() {
     # Get the starter project name
     starterProject=$(yq e '.starterProjects[0].name' $devfilePath)
     if [ "$REGISTRY" = "local" ]; then
-      $ODO_PATH create "$devfileName" --devfile "$devfilePath" --starter $starterProject || error=true
+      $ODO_PATH create --devfile "$devfilePath" --starter $starterProject || error=true
     else
       $ODO_PATH create "$devfileName" --starter $starterProject || error=true
     fi

--- a/tests/test.sh
+++ b/tests/test.sh
@@ -55,7 +55,7 @@ test() {
     fi
     
     # Get the starter project name
-    starterProject=$(yq e '.starterProjects[0].name' devfile.yaml)
+    starterProject=$(yq e '.starterProjects[0].name' $devfilePath)
     if [ "$REGISTRY" = "local" ]; then
       $ODO_PATH create "$devfileName" --devfile "$devfilePath" --starter $starterProject || error=true
     else

--- a/tests/test.sh
+++ b/tests/test.sh
@@ -54,10 +54,12 @@ test() {
         return 1
     fi
     
+    # Get the starter project name
+    starterProject=$(yq e '.starterProjects[0].name' devfile.yaml)
     if [ "$REGISTRY" = "local" ]; then
-      $ODO_PATH create "$devfileName" --devfile "$devfilePath" --starter || error=true
+      $ODO_PATH create "$devfileName" --devfile "$devfilePath" --starter $starterProject || error=true
     else
-      $ODO_PATH create "$devfileName" --starter || error=true
+      $ODO_PATH create "$devfileName" --starter $starterProject || error=true
     fi
 
     if $error; then


### PR DESCRIPTION
New version of odo requires that we change the following in the tests:
- Don't pass in devfile name when testing devfiles locally
- Must pass in the starter project name now