### PR TITLE
dotnet: fix build failing due to running application.

### DIFF
--- a/stacks/dotnet50/devfile.yaml
+++ b/stacks/dotnet50/devfile.yaml
@@ -43,7 +43,7 @@ commands:
 - id: build
   exec:
     workingDir: ${PROJECTS_ROOT}
-    commandLine: dotnet build -c $CONFIGURATION $STARTUP_PROJECT
+    commandLine: kill $(pidof dotnet); dotnet build -c $CONFIGURATION $STARTUP_PROJECT /p:UseSharedCompilation=false
     component: dotnet
     group:
       isDefault: true

--- a/stacks/dotnet50/devfile.yaml
+++ b/stacks/dotnet50/devfile.yaml
@@ -11,7 +11,7 @@ metadata:
   version: 1.0.1
 
 starterProjects:
-  - name: dotnet
+  - name: s2i-example
     git:
       checkoutFrom:
         remote: origin

--- a/stacks/dotnet50/devfile.yaml
+++ b/stacks/dotnet50/devfile.yaml
@@ -8,7 +8,7 @@ metadata:
   projectType: dotnet
   tags:
     - dotnet
-  version: 1.0.0
+  version: 1.0.1
 
 starterProjects:
   - name: dotnet

--- a/stacks/dotnetcore31/devfile.yaml
+++ b/stacks/dotnetcore31/devfile.yaml
@@ -42,7 +42,7 @@ commands:
 - id: build
   exec:
     workingDir: ${PROJECTS_ROOT}
-    commandLine: dotnet build -c $CONFIGURATION $STARTUP_PROJECT
+    commandLine: kill $(pidof dotnet); dotnet build -c $CONFIGURATION $STARTUP_PROJECT /p:UseSharedCompilation=false
     component: dotnet
     group:
       isDefault: true

--- a/stacks/dotnetcore31/devfile.yaml
+++ b/stacks/dotnetcore31/devfile.yaml
@@ -11,7 +11,7 @@ metadata:
   version: 1.0.1
 
 starterProjects:
-  - name: dotnet
+  - name: s2i-example
     git:
       checkoutFrom:
         remote: origin

--- a/stacks/dotnetcore31/devfile.yaml
+++ b/stacks/dotnetcore31/devfile.yaml
@@ -8,7 +8,7 @@ metadata:
   projectType: dotnet
   tags:
     - dotnet
-  version: 1.0.0
+  version: 1.0.1
 
 starterProjects:
   - name: dotnet


### PR DESCRIPTION
### What does this PR do?:

.NET doesn't allow the build to overwrite the files that the running
application is using.

Before starting the build, kill the 'dotnet run' process.

And, add 'UseSharedCompilation=false' to avoid 'dotnet' build processes
that stick around after the 'dotnet build'.

### PR acceptance criteria:

- [x] Contributing guide
_Have you read the [devfile registry contributing guide](https://github.com/devfile/registry/blob/main/CONTRIBUTING.md) and followed its instructions?_
- [ ] Test automation
_Does this repository's tests pass with your changes?_
- [ ] Documentation
_Does any documentation need to be updated with your changes?_

@kadel ptal.