### PR TITLE
Add viewer host alias

### DIFF
--- a/.ci/deploy/devfile-registry.yaml
+++ b/.ci/deploy/devfile-registry.yaml
@@ -179,7 +179,8 @@ objects:
     devfile-registry-hosts.json: |
       {
         "Community": {
-          "url": "http://localhost:8080"
+          "url": "http://localhost:8080",
+          "alias": "$REGISTRY_HOST_ALIAS"
         }
       }
 
@@ -232,3 +233,7 @@ parameters:
   value: devfile-community-registry
   displayName: Devfile registry name
   description: The registry name that is used as identifier for devfile telemetry
+- name: REGISTRY_HOST_ALIAS
+  value: https://registry.stage.devfile.io
+  displayName: Devfile registry hostname alias
+  description: The hostname alias to pass in to the devfile registry viewer's config.

--- a/stacks/nodejs-angular/devfile.yaml
+++ b/stacks/nodejs-angular/devfile.yaml
@@ -19,7 +19,7 @@ starterProjects:
         origin: https://github.com/devfile-samples/devfile-stack-nodejs-angular.git
 components:
   - container:
-      image: node:slim
+      image: node:lts-slim
       memoryLimit: 1024Mi
       mountSources: true
       sourceMapping: /project

--- a/stacks/nodejs-nextjs/devfile.yaml
+++ b/stacks/nodejs-nextjs/devfile.yaml
@@ -22,7 +22,7 @@ components:
       endpoints:
         - name: http
           targetPort: 3000
-      image: node:slim
+      image: node:lts-slim
       memoryLimit: 1024Mi
       mountSources: true
       sourceMapping: /project

--- a/stacks/nodejs-nuxtjs/devfile.yaml
+++ b/stacks/nodejs-nuxtjs/devfile.yaml
@@ -22,7 +22,7 @@ components:
       endpoints:
         - name: http
           targetPort: 3000
-      image: node:latest
+      image: node:lts
       memoryLimit: 1024Mi
       mountSources: true
       sourceMapping: /project

--- a/stacks/nodejs-react/devfile.yaml
+++ b/stacks/nodejs-react/devfile.yaml
@@ -19,7 +19,7 @@ starterProjects:
         origin: https://github.com/devfile-samples/devfile-stacks-nodejs-react.git
 components:
   - container:
-      image: node:slim
+      image: node:lts-slim
       memoryLimit: 1024Mi
       mountSources: true
       sourceMapping: /project

--- a/stacks/nodejs-svelte/devfile.yaml
+++ b/stacks/nodejs-svelte/devfile.yaml
@@ -19,7 +19,7 @@ starterProjects:
         origin: https://github.com/devfile-samples/devfile-stack-nodejs-svelte.git
 components:
   - container:
-      image: node:slim
+      image: node:lts-slim
       memoryLimit: 1024Mi
       mountSources: true
       sourceMapping: /project

--- a/stacks/nodejs-vue/devfile.yaml
+++ b/stacks/nodejs-vue/devfile.yaml
@@ -19,7 +19,7 @@ starterProjects:
         origin: https://github.com/devfile-samples/devfile-stack-nodejs-vue.git
 components:
   - container:
-      image: node:slim
+      image: node:lts-slim
       memoryLimit: 1024Mi
       mountSources: true
       sourceMapping: /project

--- a/tests/test.sh
+++ b/tests/test.sh
@@ -90,6 +90,7 @@ test() {
     $ODO_PATH push || error=true
     if $error; then
         echo "ERROR push failed"
+        $ODO_PATH delete -f -a || error=true
         $ODO_PATH project delete -f "$devfileName"
         FAILED_TESTS="$FAILED_TESTS $devfileName"
         return 1


### PR DESCRIPTION
Adds an env variable to the OpenShift template that sets the `alias` field in the registry viewer's config.

Also adds a small, unrelated change to the test script that makes sure we call `odo delete` when `odo push` fails.