### PR TITLE
Fix openshift template

### DIFF
--- a/.ci/deploy/devfile-registry.yaml
+++ b/.ci/deploy/devfile-registry.yaml
@@ -180,7 +180,7 @@ objects:
       {
         "Community": {
           "url": "http://localhost:8080",
-          "alias": "$REGISTRY_HOST_ALIAS"
+          "alias": "${REGISTRY_HOST_ALIAS}"
         }
       }
 


### PR DESCRIPTION
Need to add curly brackets around the env var so that AppSRE's tekton pipelines can properly set the variable.