### PR TITLE
Add dotnet60 stack

### DIFF
--- a/stacks/dotnet60/devfile.yaml
+++ b/stacks/dotnet60/devfile.yaml
@@ -1,0 +1,60 @@
+schemaVersion: 2.1.0
+metadata:
+  name: dotnet60
+  displayName: .NET 6.0
+  description: Stack with .NET 6.0
+  icon: https://developers.redhat.com/sites/default/files/styles/large/public/dotnet-logo3x3.jpg
+  language: dotnet
+  projectType: dotnet
+  tags:
+    - dotnet
+  version: 1.0.0
+
+starterProjects:
+  - name: s2i-example
+    git:
+      checkoutFrom:
+        remote: origin
+        revision: dotnet-6.0
+      remotes:
+        origin: https://github.com/redhat-developer/s2i-dotnetcore-ex
+    subDir: app
+
+
+components:
+- name: dotnet
+  container:
+    image: registry.access.redhat.com/ubi8/dotnet-60:6.0
+    mountSources: true
+    env:
+      - name: CONFIGURATION
+        value: Debug
+      - name: STARTUP_PROJECT
+        value: app.csproj
+      - name: ASPNETCORE_ENVIRONMENT
+        value: Development
+      - name: ASPNETCORE_URLS
+        value: http://*:8080
+    endpoints:
+    - name: http-8080
+      targetPort: 8080
+
+commands:
+- id: build
+  exec:
+    workingDir: ${PROJECTS_ROOT}
+    commandLine: kill $(pidof dotnet); dotnet build -c $CONFIGURATION $STARTUP_PROJECT /p:UseSharedCompilation=false
+    component: dotnet
+    group:
+      isDefault: true
+      kind: build
+
+- id: run
+  exec:
+    workingDir: ${PROJECTS_ROOT}
+    commandLine: dotnet run -c $CONFIGURATION --no-build --project $STARTUP_PROJECT --no-launch-profile
+    component: dotnet
+    group:
+      isDefault: true
+      kind: run
+


### PR DESCRIPTION
### What does this PR do?:
Adds a stack for .NET 6.0 which will be released this week.
This is a copy of the `dotnet50` stack with `5` replaced by `6` in the devfile.

### PR acceptance criteria:

- [x] Contributing guide
_Have you read the [devfile registry contributing guide](https://github.com/devfile/registry/blob/main/CONTRIBUTING.md) and followed its instructions?_
- [ ] Test automation
_Does this repository's tests pass with your changes?_
- [ ] Documentation
_Does any documentation need to be updated with your changes?_

@kadel @johnmcollier ptal.