### PR TITLE
Jan 2022 updates to open-liberty and websphere-liberty stacks

### DIFF
--- a/stacks/java-openliberty-gradle/devfile.yaml
+++ b/stacks/java-openliberty-gradle/devfile.yaml
@@ -1,4 +1,4 @@
-# Copyright (c) 2021 IBM Corporation and others
+# Copyright (c) 2021,2022 IBM Corporation and others
 #
 # See the NOTICE file(s) distributed with this work for additional
 # information regarding copyright ownership.
@@ -17,7 +17,7 @@
 schemaVersion: 2.1.0
 metadata:
   name: java-openliberty-gradle
-  version: 0.3.0
+  version: 0.3.1
   displayName: 'Open Liberty Gradle'
   description: Java application Gradle-built stack using the Open Liberty runtime
   icon: https://raw.githubusercontent.com/OpenLiberty/logos/7fbb132949b9b2589e18c8d5665c1b107028a21d/logomark/svg/OL_logomark.svg
@@ -25,8 +25,8 @@ metadata:
   architectures: ['amd64', 'ppc64le', 's390x']
   language: 'java'
   projectType: 'openliberty'
-  alpha.build-dockerfile: 'https://github.com/OpenLiberty/devfile-stack/releases/download/open-liberty-gradle-0.3.0/Dockerfile'
-  alpha.deployment-manifest: 'https://github.com/OpenLiberty/devfile-stack/releases/download/open-liberty-gradle-0.3.0/app-deploy.yaml'
+  alpha.build-dockerfile: 'https://github.com/OpenLiberty/devfile-stack/releases/download/open-liberty-gradle-0.3.1/Dockerfile'
+  alpha.deployment-manifest: 'https://github.com/OpenLiberty/devfile-stack/releases/download/open-liberty-gradle-0.3.1/app-deploy.yaml'
 starterProjects:
   - name: rest
     git:
@@ -34,12 +34,13 @@ starterProjects:
         origin: 'https://github.com/OpenLiberty/devfile-stack-starters.git'
 variables:
   # Liberty runtime version. Minimum recommended: 21.0.0.9
-  liberty-version: 21.0.0.12
+  liberty-version: '22.0.0.1'
+  gradle-cmd: 'gradle'
 components:
   - name: dev
     container:
       image: icr.io/appcafe/open-liberty-devfile-stack:{{liberty-version}}-gradle
-      memoryLimit: 1512Mi
+      memoryLimit: 1280Mi
       mountSources: true
       endpoints:
         - exposure: public
@@ -51,7 +52,7 @@ commands:
   - id: run
     exec:
       component: dev
-      commandLine: gradle -Dgradle.user.home=/.gradle libertyDev -Pliberty.runtime.version={{liberty-version}} -Pliberty.runtime.name=openliberty-runtime -Pliberty.runtime.group=io.openliberty --libertyDebug=false --hotTests --compileWait=3
+      commandLine: echo "gradle run command"; {{gradle-cmd}} -Dgradle.user.home=/.gradle libertyDev -Pliberty.runtime.version={{liberty-version}} -Pliberty.runtime.name=openliberty-runtime -Pliberty.runtime.group=io.openliberty --libertyDebug=false --hotTests --compileWait=3
       workingDir: /projects
       hotReloadCapable: true
       group:
@@ -60,7 +61,7 @@ commands:
   - id: run-test-off
     exec:
       component: dev
-      commandLine: gradle -Dgradle.user.home=/.gradle libertyDev -Pliberty.runtime.version={{liberty-version}} -Pliberty.runtime.name=openliberty-runtime -Pliberty.runtime.group=io.openliberty --libertyDebug=false
+      commandLine: echo "gradle run-tests-off command "; {{gradle-cmd}} -Dgradle.user.home=/.gradle libertyDev -Pliberty.runtime.version={{liberty-version}} -Pliberty.runtime.name=openliberty-runtime -Pliberty.runtime.group=io.openliberty --libertyDebug=false
       workingDir: /projects
       hotReloadCapable: true
       group:
@@ -69,7 +70,7 @@ commands:
   - id: debug
     exec:
       component: dev
-      commandLine: gradle -Dgradle.user.home=/.gradle libertyDev -Pliberty.runtime.version={{liberty-version}} -Pliberty.runtime.name=openliberty-runtime -Pliberty.runtime.group=io.openliberty --libertyDebugPort=${DEBUG_PORT} -Pliberty.server.env.WLP_DEBUG_REMOTE=y
+      commandLine: echo "gradle debug command "; {{gradle-cmd}} -Dgradle.user.home=/.gradle libertyDev -Pliberty.runtime.version={{liberty-version}} -Pliberty.runtime.name=openliberty-runtime -Pliberty.runtime.group=io.openliberty --libertyDebugPort=${DEBUG_PORT} -Pliberty.server.env.WLP_DEBUG_REMOTE=y
       workingDir: /projects
       hotReloadCapable: true
       group:
@@ -78,7 +79,7 @@ commands:
   - id: test
     exec:
       component: dev
-      commandLine: gradle -Dgradle.user.home=/.gradle test -Pliberty.runtime.version={{liberty-version}} -Pliberty.runtime.name=openliberty-runtime -Pliberty.runtime.group=io.openliberty
+      commandLine: echo "gradle test command "; {{gradle-cmd}} -Dgradle.user.home=/.gradle test -Pliberty.runtime.version={{liberty-version}} -Pliberty.runtime.name=openliberty-runtime -Pliberty.runtime.group=io.openliberty
       workingDir: /projects
       hotReloadCapable: true
       group:

--- a/stacks/java-openliberty/devfile.yaml
+++ b/stacks/java-openliberty/devfile.yaml
@@ -1,4 +1,4 @@
-# Copyright (c) 2021 IBM Corporation and others
+# Copyright (c) 2021,2022 IBM Corporation and others
 #
 # See the NOTICE file(s) distributed with this work for additional
 # information regarding copyright ownership.
@@ -17,7 +17,7 @@
 schemaVersion: 2.1.0
 metadata:
   name: java-openliberty
-  version: 0.8.0
+  version: 0.8.1
   displayName: 'Open Liberty Maven'
   description: Java application Maven-built stack using the Open Liberty runtime
   icon: https://raw.githubusercontent.com/OpenLiberty/logos/7fbb132949b9b2589e18c8d5665c1b107028a21d/logomark/svg/OL_logomark.svg
@@ -25,8 +25,8 @@ metadata:
   architectures: ['amd64', 'ppc64le', 's390x']
   language: 'java'
   projectType: 'openliberty'
-  alpha.build-dockerfile: 'https://github.com/OpenLiberty/devfile-stack/releases/download/open-liberty-maven-0.8.0/Dockerfile'
-  alpha.deployment-manifest: 'https://github.com/OpenLiberty/devfile-stack/releases/download/open-liberty-maven-0.8.0/app-deploy.yaml'
+  alpha.build-dockerfile: 'https://github.com/OpenLiberty/devfile-stack/releases/download/open-liberty-maven-0.8.1/Dockerfile'
+  alpha.deployment-manifest: 'https://github.com/OpenLiberty/devfile-stack/releases/download/open-liberty-maven-0.8.1/app-deploy.yaml'
 starterProjects:
   - name: rest
     git:
@@ -34,14 +34,15 @@ starterProjects:
         origin: 'https://github.com/OpenLiberty/devfile-stack-starters.git'
 variables:
   # Liberty runtime version. Minimum recommended: 21.0.0.9
-  liberty-version: "21.0.0.12"
-  liberty-plugin-version: "3.5.1"
+  liberty-version: '22.0.0.1'
+  liberty-plugin-version: '3.5.1'
+  mvn-cmd: 'mvn'
 components:
   - name: dev
     container:
       # In the original upstream of this devfile, the image used is openliberty/devfile-stack:<x.y.z>, which is built from the repository: https://github.com/OpenLiberty/devfile-stack
       image: icr.io/appcafe/open-liberty-devfile-stack:{{liberty-version}}
-      memoryLimit: 1512Mi
+      memoryLimit: 768Mi
       mountSources: true
       endpoints:
         - exposure: public
@@ -53,7 +54,7 @@ commands:
   - id: run
     exec:
       component: dev
-      commandLine: mvn -DinstallDirectory=/opt/ol/wlp -Ddebug=false -DhotTests=true -DcompileWait=3 io.openliberty.tools:liberty-maven-plugin:{{liberty-plugin-version}}:dev
+      commandLine:  echo "run command "; {{mvn-cmd}} -DinstallDirectory=/opt/ol/wlp -Ddebug=false -DhotTests=true -DcompileWait=3 io.openliberty.tools:liberty-maven-plugin:{{liberty-plugin-version}}:dev
       workingDir: /projects
       hotReloadCapable: true
       group:
@@ -62,7 +63,7 @@ commands:
   - id: run-test-off
     exec:
       component: dev
-      commandLine: mvn -DinstallDirectory=/opt/ol/wlp -Ddebug=false io.openliberty.tools:liberty-maven-plugin:{{liberty-plugin-version}}:dev
+      commandLine: echo "run-test-off command "; {{mvn-cmd}} -DinstallDirectory=/opt/ol/wlp -Ddebug=false io.openliberty.tools:liberty-maven-plugin:{{liberty-plugin-version}}:dev
       workingDir: /projects
       hotReloadCapable: true
       group:
@@ -71,7 +72,7 @@ commands:
   - id: debug
     exec:
       component: dev
-      commandLine: mvn -DinstallDirectory=/opt/ol/wlp -DdebugPort=${DEBUG_PORT} io.openliberty.tools:liberty-maven-plugin:{{liberty-plugin-version}}:dev -Dliberty.env.WLP_DEBUG_REMOTE=y
+      commandLine: echo "debug command "; {{mvn-cmd}} -DinstallDirectory=/opt/ol/wlp -DdebugPort=${DEBUG_PORT} io.openliberty.tools:liberty-maven-plugin:{{liberty-plugin-version}}:dev -Dliberty.env.WLP_DEBUG_REMOTE=y
       workingDir: /projects
       hotReloadCapable: true
       group:
@@ -81,7 +82,7 @@ commands:
     # The 'test' command requires an already active container. Multi-module apps require compilation prior to test processing.
     exec:
       component: dev
-      commandLine: mvn compiler:compile failsafe:integration-test failsafe:verify
+      commandLine: echo "test command "; {{mvn-cmd}} compiler:compile failsafe:integration-test failsafe:verify
       workingDir: /projects
       hotReloadCapable: true
       group:

--- a/stacks/java-websphereliberty-gradle/devfile.yaml
+++ b/stacks/java-websphereliberty-gradle/devfile.yaml
@@ -1,4 +1,4 @@
-# Copyright (c) 2021 IBM Corporation and others
+# Copyright (c) 2021,2022 IBM Corporation and others
 #
 # See the NOTICE file(s) distributed with this work for additional
 # information regarding copyright ownership.
@@ -17,7 +17,7 @@
 schemaVersion: 2.1.0
 metadata:
   name: java-websphereliberty-gradle
-  version: 0.3.0
+  version: 0.3.1
   displayName: 'WebSphere Liberty Gradle'
   description: Java application Gradle-built stack using the WebSphere Liberty runtime
   icon: https://raw.githubusercontent.com/OpenLiberty/logos/7fbb132949b9b2589e18c8d5665c1b107028a21d/logomark/svg/OL_logomark.svg
@@ -25,8 +25,8 @@ metadata:
   architectures: ['amd64', 'ppc64le', 's390x']
   language: 'java'
   projectType: 'websphereliberty'
-  alpha.build-dockerfile: 'https://github.com/OpenLiberty/devfile-stack/releases/download/websphere-liberty-gradle-0.3.0/Dockerfile'
-  alpha.deployment-manifest: 'https://github.com/OpenLiberty/devfile-stack/releases/download/websphere-liberty-gradle-0.3.0/app-deploy.yaml'
+  alpha.build-dockerfile: 'https://github.com/OpenLiberty/devfile-stack/releases/download/websphere-liberty-gradle-0.3.1/Dockerfile'
+  alpha.deployment-manifest: 'https://github.com/OpenLiberty/devfile-stack/releases/download/websphere-liberty-gradle-0.3.1/app-deploy.yaml'
 starterProjects:
   - name: rest
     git:
@@ -34,12 +34,13 @@ starterProjects:
         origin: 'https://github.com/OpenLiberty/devfile-stack-starters.git'
 variables:
   # Liberty runtime version. Minimum recommended: 21.0.0.9
-  liberty-version: 21.0.0.12
+  liberty-version: '22.0.0.1'
+  gradle-cmd: 'gradle'
 components:
   - name: dev
     container:
       image: icr.io/appcafe/websphere-liberty-devfile-stack:{{liberty-version}}-gradle
-      memoryLimit: 1512Mi
+      memoryLimit: 1280Mi
       mountSources: true
       endpoints:
         - exposure: public
@@ -51,7 +52,7 @@ commands:
   - id: run
     exec:
       component: dev
-      commandLine: gradle -Dgradle.user.home=/.gradle libertyDev -Pliberty.runtime.version={{liberty-version}} -Pliberty.runtime.name=wlp-javaee8 -Pliberty.runtime.group=com.ibm.websphere.appserver.runtime --libertyDebug=false --hotTests --compileWait=3
+      commandLine: echo "gradle run command"; {{gradle-cmd}} -Dgradle.user.home=/.gradle libertyDev -Pliberty.runtime.version={{liberty-version}} -Pliberty.runtime.name=wlp-javaee8 -Pliberty.runtime.group=com.ibm.websphere.appserver.runtime --libertyDebug=false --hotTests --compileWait=3
       workingDir: /projects
       hotReloadCapable: true
       group:
@@ -60,7 +61,7 @@ commands:
   - id: run-test-off
     exec:
       component: dev
-      commandLine: gradle -Dgradle.user.home=/.gradle libertyDev -Pliberty.runtime.version={{liberty-version}} -Pliberty.runtime.name=wlp-javaee8 -Pliberty.runtime.group=com.ibm.websphere.appserver.runtime --libertyDebug=false
+      commandLine: echo "gradle run-tests-off command "; {{gradle-cmd}} -Dgradle.user.home=/.gradle libertyDev -Pliberty.runtime.version={{liberty-version}} -Pliberty.runtime.name=wlp-javaee8 -Pliberty.runtime.group=com.ibm.websphere.appserver.runtime --libertyDebug=false
       workingDir: /projects
       hotReloadCapable: true
       group:
@@ -69,7 +70,7 @@ commands:
   - id: debug
     exec:
       component: dev
-      commandLine: gradle -Dgradle.user.home=/.gradle libertyDev -Pliberty.runtime.version={{liberty-version}} -Pliberty.runtime.name=wlp-javaee8 -Pliberty.runtime.group=com.ibm.websphere.appserver.runtime --libertyDebugPort=${DEBUG_PORT} -Pliberty.server.env.WLP_DEBUG_REMOTE=y
+      commandLine: echo "gradle debug command "; {{gradle-cmd}} -Dgradle.user.home=/.gradle libertyDev -Pliberty.runtime.version={{liberty-version}} -Pliberty.runtime.name=wlp-javaee8 -Pliberty.runtime.group=com.ibm.websphere.appserver.runtime --libertyDebugPort=${DEBUG_PORT} -Pliberty.server.env.WLP_DEBUG_REMOTE=y
       workingDir: /projects
       hotReloadCapable: true
       group:
@@ -78,7 +79,7 @@ commands:
   - id: test
     exec:
       component: dev
-      commandLine: gradle -Dgradle.user.home=/.gradle test -Pliberty.runtime.version={{liberty-version}} -Pliberty.runtime.name=wlp-javaee8 -Pliberty.runtime.group=com.ibm.websphere.appserver.runtime
+      commandLine: echo "gradle test command "; {{gradle-cmd}} -Dgradle.user.home=/.gradle test -Pliberty.runtime.version={{liberty-version}} -Pliberty.runtime.name=wlp-javaee8 -Pliberty.runtime.group=com.ibm.websphere.appserver.runtime
       workingDir: /projects
       hotReloadCapable: true
       group:

--- a/stacks/java-websphereliberty/devfile.yaml
+++ b/stacks/java-websphereliberty/devfile.yaml
@@ -1,4 +1,4 @@
-# Copyright (c) 2021 IBM Corporation and others
+# Copyright (c) 2021,2022 IBM Corporation and others
 #
 # See the NOTICE file(s) distributed with this work for additional
 # information regarding copyright ownership.
@@ -17,7 +17,7 @@
 schemaVersion: 2.1.0
 metadata:
   name: java-websphereliberty
-  version: 0.8.0
+  version: 0.8.1
   displayName: 'WebSphere Liberty Maven'
   description: Java application Maven-built stack using the WebSphere Liberty runtime
   icon: https://raw.githubusercontent.com/OpenLiberty/logos/7fbb132949b9b2589e18c8d5665c1b107028a21d/logomark/svg/OL_logomark.svg
@@ -25,8 +25,8 @@ metadata:
   architectures: ['amd64', 'ppc64le', 's390x']
   language: 'java'
   projectType: 'websphereliberty'
-  alpha.build-dockerfile: 'https://github.com/OpenLiberty/devfile-stack/releases/download/websphere-liberty-maven-0.8.0/Dockerfile'
-  alpha.deployment-manifest: 'https://github.com/OpenLiberty/devfile-stack/releases/download/websphere-liberty-maven-0.8.0/app-deploy.yaml'
+  alpha.build-dockerfile: 'https://github.com/OpenLiberty/devfile-stack/releases/download/websphere-liberty-maven-0.8.1/Dockerfile'
+  alpha.deployment-manifest: 'https://github.com/OpenLiberty/devfile-stack/releases/download/websphere-liberty-maven-0.8.1/app-deploy.yaml'
 starterProjects:
   - name: rest
     git:
@@ -34,14 +34,15 @@ starterProjects:
         origin: 'https://github.com/OpenLiberty/devfile-stack-starters.git'
 variables:
   # Liberty runtime version. Minimum recommended: 21.0.0.9
-  liberty-version: "21.0.0.12"
-  liberty-plugin-version: "3.5.1"
+  liberty-version: '22.0.0.1'
+  liberty-plugin-version: '3.5.1'
+  mvn-cmd: 'mvn'
 components:
   - name: dev
     container:
       # In the original upstream of this devfile, the image used is openliberty/devfile-stack:<x.y.z>, which is built from the repository: https://github.com/OpenLiberty/devfile-stack
       image: icr.io/appcafe/websphere-liberty-devfile-stack:{{liberty-version}}
-      memoryLimit: 1512Mi
+      memoryLimit: 768Mi
       mountSources: true
       endpoints:
         - exposure: public
@@ -53,7 +54,7 @@ commands:
   - id: run
     exec:
       component: dev
-      commandLine: mvn -DinstallDirectory=/opt/ibm/wlp -Ddebug=false -DhotTests=true -DcompileWait=3 io.openliberty.tools:liberty-maven-plugin:{{liberty-plugin-version}}:dev
+      commandLine:  echo "run command "; {{mvn-cmd}} -DinstallDirectory=/opt/ibm/wlp -Ddebug=false -DhotTests=true -DcompileWait=3 io.openliberty.tools:liberty-maven-plugin:{{liberty-plugin-version}}:dev
       workingDir: /projects
       hotReloadCapable: true
       group:
@@ -62,7 +63,7 @@ commands:
   - id: run-test-off
     exec:
       component: dev
-      commandLine: mvn -DinstallDirectory=/opt/ibm/wlp -Ddebug=false io.openliberty.tools:liberty-maven-plugin:{{liberty-plugin-version}}:dev
+      commandLine: echo "run-test-off command "; {{mvn-cmd}} -DinstallDirectory=/opt/ibm/wlp -Ddebug=false io.openliberty.tools:liberty-maven-plugin:{{liberty-plugin-version}}:dev
       workingDir: /projects
       hotReloadCapable: true
       group:
@@ -71,7 +72,7 @@ commands:
   - id: debug
     exec:
       component: dev
-      commandLine: mvn -DinstallDirectory=/opt/ibm/wlp -DdebugPort=${DEBUG_PORT} io.openliberty.tools:liberty-maven-plugin:{{liberty-plugin-version}}:dev -Dliberty.env.WLP_DEBUG_REMOTE=y
+      commandLine: echo "debug command "; {{mvn-cmd}} -DinstallDirectory=/opt/ibm/wlp -DdebugPort=${DEBUG_PORT} io.openliberty.tools:liberty-maven-plugin:{{liberty-plugin-version}}:dev -Dliberty.env.WLP_DEBUG_REMOTE=y
       workingDir: /projects
       hotReloadCapable: true
       group:
@@ -81,7 +82,7 @@ commands:
     # The 'test' command requires an already active container. Multi-module apps require compilation prior to test processing.
     exec:
       component: dev
-      commandLine: mvn compiler:compile failsafe:integration-test failsafe:verify
+      commandLine: echo "test command "; {{mvn-cmd}} compiler:compile failsafe:integration-test failsafe:verify
       workingDir: /projects
       hotReloadCapable: true
       group:


### PR DESCRIPTION
Signed-off-by: Andrew Mauer <ajmauer@gmail.com>

### What does this PR do?:
Existing stacks updated:

- java-openliberty
- java-openliberty-gradle
- java-websphereliberty
- java-websphereliberty-gradle

Updates:
- devfile variable to allow config of what mvn and gradle commands are used
- devfile component container memoryLimit value was updated.
- app-deploy.yaml is now compatible with Open Liberty Operator version 0.8.0
- updated liberty images used in each of the stacks

### Which issue(s) this PR fixes:
https://github.com/OpenLiberty/devfile-stack/issues/185
https://github.com/OpenLiberty/devfile-stack/issues/197

### PR acceptance criteria:

- [x] Contributing guide
_Have you read the [devfile registry contributing guide](https://github.com/devfile/registry/blob/main/CONTRIBUTING.md) and followed its instructions?_
- [x] Test automation
_All javaliberty and websphereliberty testcases pass_
- [x] Documentation
_No doc update needed_


### How to test changes / Special notes to the reviewer: