### PR TITLE
add missing DEBUG_PORT env variable

### DIFF
--- a/stacks/java-maven/devfile.yaml
+++ b/stacks/java-maven/devfile.yaml
@@ -25,6 +25,9 @@ components:
       volumeMounts:
         - name: m2
           path: /home/user/.m2
+      env:
+        - name: DEBUG_PORT
+          value: "5858"
   - name: m2
     volume: {}
 commands:

--- a/stacks/java-openliberty-gradle/devfile.yaml
+++ b/stacks/java-openliberty-gradle/devfile.yaml
@@ -48,6 +48,9 @@ components:
           name: ep1
           targetPort: 9080
           protocol: http
+      env:
+        - name: DEBUG_PORT
+          value: "5858"
 commands:
   - id: run
     exec:

--- a/stacks/java-openliberty/devfile.yaml
+++ b/stacks/java-openliberty/devfile.yaml
@@ -50,6 +50,9 @@ components:
           name: ep1
           targetPort: 9080
           protocol: http
+      env:
+        - name: DEBUG_PORT
+          value: "5858"
 commands:
   - id: run
     exec:

--- a/stacks/java-quarkus/devfile.yaml
+++ b/stacks/java-quarkus/devfile.yaml
@@ -28,6 +28,9 @@ components:
       endpoints:
         - name: '8080-http'
           targetPort: 8080
+      env:
+        - name: DEBUG_PORT
+          value: "5858"
   - name: m2
     volume:
       size: 3Gi

--- a/stacks/java-springboot/devfile.yaml
+++ b/stacks/java-springboot/devfile.yaml
@@ -26,6 +26,9 @@ components:
       volumeMounts:
         - name: m2
           path: /home/user/.m2
+      env:
+        - name: DEBUG_PORT
+          value: "5858"
   - name: m2
     volume:
       size: 3Gi

--- a/stacks/java-vertx/devfile.yaml
+++ b/stacks/java-vertx/devfile.yaml
@@ -100,6 +100,9 @@ components:
       volumeMounts:
         - name: m2
           path: /home/user/.m2
+      env:
+        - name: DEBUG_PORT
+          value: "5858"
   - name: m2
     volume:
       size: 3Gi

--- a/stacks/java-websphereliberty-gradle/devfile.yaml
+++ b/stacks/java-websphereliberty-gradle/devfile.yaml
@@ -48,6 +48,9 @@ components:
           name: ep1
           targetPort: 9080
           protocol: http
+      env:
+        - name: DEBUG_PORT
+          value: "5858"
 commands:
   - id: run
     exec:

--- a/stacks/java-websphereliberty/devfile.yaml
+++ b/stacks/java-websphereliberty/devfile.yaml
@@ -50,6 +50,9 @@ components:
           name: ep1
           targetPort: 9080
           protocol: http
+      env:
+        - name: DEBUG_PORT
+          value: "5858"
 commands:
   - id: run
     exec:

--- a/stacks/java-wildfly-bootable-jar/devfile.yaml
+++ b/stacks/java-wildfly-bootable-jar/devfile.yaml
@@ -120,6 +120,8 @@ components:
           value: '-Djava.security.egd=file:/dev/urandom'
         - name: MVN_ARGS_APPEND
           value: '-Pbootable-jar-openshift -Djkube.skip=true -s /home/jboss/.m2/settings.xml -Dmaven.repo.local=/home/jboss/.m2/repository -Dcom.redhat.xpaas.repo.jbossorg'
+        - name: DEBUG_PORT
+          value: "5858"
       endpoints:
         - name: 'http'
           targetPort: 8080

--- a/stacks/java-wildfly/devfile.yaml
+++ b/stacks/java-wildfly/devfile.yaml
@@ -108,6 +108,8 @@ components:
           value: '/projects/wildfly'
         - name: MVN_ARGS_APPEND
           value: '-s /home/jboss/.m2/settings.xml -Dmaven.repo.local=/home/jboss/.m2/repository -Dcom.redhat.xpaas.repo.jbossorg'
+        - name: DEBUG_PORT
+          value: "5858"
       endpoints:
         - name: 'wildfly-http'
           targetPort: 8080

--- a/stacks/python-django/devfile.yaml
+++ b/stacks/python-django/devfile.yaml
@@ -21,6 +21,9 @@ components:
       endpoints:
         - name: web
           targetPort: 8000
+      env:
+        - name: DEBUG_PORT
+          value: "5858"
 commands:
   - id: pip-install-requirements
     exec:

--- a/stacks/python/devfile.yaml
+++ b/stacks/python/devfile.yaml
@@ -21,6 +21,9 @@ components:
       endpoints:
         - name: web
           targetPort: 8080
+      env:
+        - name: DEBUG_PORT
+          value: "5858"
 commands:
   - id: pip-install-requirements
     exec:


### PR DESCRIPTION
### What does this PR do?:
Debug commands are using `DEBUG_PORT` variable but that variable is not defined in containers.
This was not an issue for `odo` as it automatically injects this variable if it is not defined, but this creates problems for other tools.



### Which issue(s) this PR fixes:
fixes one of the items in https://github.com/devfile/api/issues/679

### PR acceptance criteria:

- [x] Contributing guide
_Have you read the [devfile registry contributing guide](https://github.com/devfile/registry/blob/main/CONTRIBUTING.md) and followed its instructions?_
- [x] Test automation
_Does this repository's tests pass with your changes?_
- [x] Documentation
_Does any documentation need to be updated with your changes?_
