### PR TITLE
OpenShift CI: Download latest odo rather than building from main

### DIFF
--- a/.ci/openshift_integration.sh
+++ b/.ci/openshift_integration.sh
@@ -33,7 +33,7 @@ curl -sL https://github.com/mikefarah/yq/releases/download/v4.9.5/yq_linux_amd64
 YQ_PATH=$(realpath yq)
 
 # Download odo
-curl -sL https://developers.redhat.com/content-gateway/file/pub/openshift-v4/clients/odo/v2.5.0/odo-linux-amd64 -o odo && chmod +x odo
+curl -sL https://developers.redhat.com/content-gateway/rest/mirror/pub/openshift-v4/clients/odo/latest/odo-linux-amd64 -o odo && chmod +x odo
 export GLOBALODOCONFIG=$(pwd)/preferences.yaml
 
 # Install the devfile registry

--- a/.ci/openshift_integration.sh
+++ b/.ci/openshift_integration.sh
@@ -32,11 +32,6 @@ oc new-project devfile-registry-test
 curl -sL https://github.com/mikefarah/yq/releases/download/v4.9.5/yq_linux_amd64 -o yq && chmod +x yq
 YQ_PATH=$(realpath yq)
 
-# Build odo
-#git clone https://github.com/openshift/odo.git
-#cd odo && make
-#cd ..
-
 # Download odo
 curl -sL https://developers.redhat.com/content-gateway/file/pub/openshift-v4/clients/odo/v2.5.0/odo-linux-amd64 -o odo && chmod +x odo
 export GLOBALODOCONFIG=$(pwd)/preferences.yaml

--- a/.ci/openshift_integration.sh
+++ b/.ci/openshift_integration.sh
@@ -33,10 +33,12 @@ curl -sL https://github.com/mikefarah/yq/releases/download/v4.9.5/yq_linux_amd64
 YQ_PATH=$(realpath yq)
 
 # Build odo
-git clone https://github.com/openshift/odo.git
-cd odo && make
-cd ..
+#git clone https://github.com/openshift/odo.git
+#cd odo && make
+#cd ..
 
+# Download odo
+curl -sL https://developers.redhat.com/content-gateway/file/pub/openshift-v4/clients/odo/v2.5.0/odo-linux-amd64 -o odo && chmod +x odo
 export GLOBALODOCONFIG=$(pwd)/preferences.yaml
 
 # Install the devfile registry
@@ -55,8 +57,8 @@ REGISTRY_HOSTNAME=$(oc get route devfile-registry -o jsonpath="{.spec.host}")
 echo $REGISTRY_HOSTNAME
 
 # Delete the default devfile registry and add the test one we just stood up
-$(realpath odo/odo) registry delete DefaultDevfileRegistry -f
-$(realpath odo/odo) registry add TestDevfileRegistry http://$REGISTRY_HOSTNAME
+$(realpath odo) registry delete DefaultDevfileRegistry -f
+$(realpath odo) registry add TestDevfileRegistry http://$REGISTRY_HOSTNAME
 
 # Run the devfile validation tests
-ENV=openshift REGISTRY=remote tests/test.sh $(realpath odo/odo) $YQ_PATH
+ENV=openshift REGISTRY=remote tests/test.sh $(realpath odo) $YQ_PATH

--- a/stacks/python-django/devfile.yaml
+++ b/stacks/python-django/devfile.yaml
@@ -12,7 +12,7 @@ starterProjects:
   - name: django-example
     git:
       remotes:
-        origin: https://github.com/odo-devfiles/python-django-ex
+        origin: https://github.com/devfile-samples/python-django-ex
 components:
   - name: py-web
     container:

--- a/stacks/python/devfile.yaml
+++ b/stacks/python/devfile.yaml
@@ -12,7 +12,7 @@ starterProjects:
   - name: python-example
     git:
       remotes:
-        origin: https://github.com/odo-devfiles/python-ex
+        origin: https://github.com/devfile-samples/python-ex
 components:
   - name: py-web
     container:


### PR DESCRIPTION
### What does this PR do?:
Updates the OpenShift CI script to download the latest odo from https://developers.redhat.com/content-gateway/rest/mirror/pub/openshift-v4/clients/odo/latest rather than building the latest odo from main

Makes the script consistent with our github action (at least once https://github.com/devfile/api/issues/771 is fixed)

### Which issue(s) this PR fixes:
N/A

