### PR TITLE
Use registry.access.redhat.com/ubi8/nodejs-16-minimal for nodejs-vue

### DIFF
--- a/stacks/nodejs-vue/devfile.yaml
+++ b/stacks/nodejs-vue/devfile.yaml
@@ -22,7 +22,7 @@ components:
       endpoints:
         - name: http
           targetPort: 3000
-      image: node:lts-slim
+      image: registry.access.redhat.com/ubi8/nodejs-16-minimal
       memoryLimit: 1024Mi
     name: runtime
 commands:


### PR DESCRIPTION
Switches to a UBI image for nodejs-vue to avoid some potential permissions issues on openshift