### PR TITLE
Override Cypress Cache folder for nodejs-vue 

### DIFF
--- a/stacks/nodejs-vue/devfile.yaml
+++ b/stacks/nodejs-vue/devfile.yaml
@@ -19,6 +19,9 @@ starterProjects:
         origin: https://github.com/devfile-samples/devfile-stack-nodejs-vue.git
 components:
   - container:
+      env:
+        - name: CYPRESS_CACHE_FOLDER
+          value: ${PROJECT_SOURCE}
       endpoints:
         - name: http
           targetPort: 3000


### PR DESCRIPTION
Avoids the pesky permissions issues on OpenShift