### PR TITLE
Replace hardcoded `/projects/` with `${PROJECT_SOURCE}`

### DIFF
--- a/stacks/java-websphereliberty-gradle/devfile.yaml
+++ b/stacks/java-websphereliberty-gradle/devfile.yaml
@@ -56,7 +56,7 @@ commands:
     exec:
       component: dev
       commandLine: echo "gradle run command"; {{gradle-cmd}} -Dgradle.user.home=/.gradle libertyDev -Pliberty.runtime.version={{liberty-version}} -Pliberty.runtime.name=wlp-javaee8 -Pliberty.runtime.group=com.ibm.websphere.appserver.runtime --libertyDebug=false --hotTests --compileWait=3
-      workingDir: /projects
+      workingDir: ${PROJECT_SOURCE}
       hotReloadCapable: true
       group:
         kind: run
@@ -65,7 +65,7 @@ commands:
     exec:
       component: dev
       commandLine: echo "gradle run-tests-off command "; {{gradle-cmd}} -Dgradle.user.home=/.gradle libertyDev -Pliberty.runtime.version={{liberty-version}} -Pliberty.runtime.name=wlp-javaee8 -Pliberty.runtime.group=com.ibm.websphere.appserver.runtime --libertyDebug=false
-      workingDir: /projects
+      workingDir: ${PROJECT_SOURCE}
       hotReloadCapable: true
       group:
         kind: run
@@ -74,7 +74,7 @@ commands:
     exec:
       component: dev
       commandLine: echo "gradle debug command "; {{gradle-cmd}} -Dgradle.user.home=/.gradle libertyDev -Pliberty.runtime.version={{liberty-version}} -Pliberty.runtime.name=wlp-javaee8 -Pliberty.runtime.group=com.ibm.websphere.appserver.runtime --libertyDebugPort=${DEBUG_PORT} -Pliberty.server.env.WLP_DEBUG_REMOTE=y
-      workingDir: /projects
+      workingDir: ${PROJECT_SOURCE}
       hotReloadCapable: true
       group:
         kind: debug
@@ -83,7 +83,7 @@ commands:
     exec:
       component: dev
       commandLine: echo "gradle test command "; {{gradle-cmd}} -Dgradle.user.home=/.gradle test -Pliberty.runtime.version={{liberty-version}} -Pliberty.runtime.name=wlp-javaee8 -Pliberty.runtime.group=com.ibm.websphere.appserver.runtime
-      workingDir: /projects
+      workingDir: ${PROJECT_SOURCE}
       hotReloadCapable: true
       group:
         kind: test

--- a/stacks/java-websphereliberty/devfile.yaml
+++ b/stacks/java-websphereliberty/devfile.yaml
@@ -58,7 +58,7 @@ commands:
     exec:
       component: dev
       commandLine:  echo "run command "; {{mvn-cmd}} -DinstallDirectory=/opt/ibm/wlp -Ddebug=false -DhotTests=true -DcompileWait=3 io.openliberty.tools:liberty-maven-plugin:{{liberty-plugin-version}}:dev
-      workingDir: /projects
+      workingDir: ${PROJECT_SOURCE}
       hotReloadCapable: true
       group:
         kind: run
@@ -67,7 +67,7 @@ commands:
     exec:
       component: dev
       commandLine: echo "run-test-off command "; {{mvn-cmd}} -DinstallDirectory=/opt/ibm/wlp -Ddebug=false io.openliberty.tools:liberty-maven-plugin:{{liberty-plugin-version}}:dev
-      workingDir: /projects
+      workingDir: ${PROJECT_SOURCE}
       hotReloadCapable: true
       group:
         kind: run
@@ -76,7 +76,7 @@ commands:
     exec:
       component: dev
       commandLine: echo "debug command "; {{mvn-cmd}} -DinstallDirectory=/opt/ibm/wlp -DdebugPort=${DEBUG_PORT} io.openliberty.tools:liberty-maven-plugin:{{liberty-plugin-version}}:dev -Dliberty.env.WLP_DEBUG_REMOTE=y
-      workingDir: /projects
+      workingDir: ${PROJECT_SOURCE}
       hotReloadCapable: true
       group:
         kind: debug
@@ -86,7 +86,7 @@ commands:
     exec:
       component: dev
       commandLine: echo "test command "; {{mvn-cmd}} compiler:compile failsafe:integration-test failsafe:verify
-      workingDir: /projects
+      workingDir: ${PROJECT_SOURCE}
       hotReloadCapable: true
       group:
         kind: test


### PR DESCRIPTION
### What does this PR do?:

Replace deprecated `/projects` with `${PROJECT_SOURCE}` 

### Which issue(s) this PR fixes:

https://github.com/devfile/api/issues/681

### PR acceptance criteria:

- [x] Contributing guide
- [x] Test automation
- [x] Documentation

### How to test changes / Special notes to the reviewer: