### PR TITLE
Hardcode to odo v2.5.1 for tests

### DIFF
--- a/.ci/openshift_integration.sh
+++ b/.ci/openshift_integration.sh
@@ -33,7 +33,7 @@ curl -sL https://github.com/mikefarah/yq/releases/download/v4.9.5/yq_linux_amd64
 YQ_PATH=$(realpath yq)
 
 # Download odo
-curl -sL https://developers.redhat.com/content-gateway/rest/mirror/pub/openshift-v4/clients/odo/latest/odo-linux-amd64 -o odo && chmod +x odo
+curl -sL https://developers.redhat.com/content-gateway/rest/mirror/pub/openshift-v4/clients/odo/v2.5.1/odo-linux-amd64 -o odo && chmod +x odo
 export GLOBALODOCONFIG=$(pwd)/preferences.yaml
 
 # Install the devfile registry

--- a/.github/workflows/validate-devfiles-minikube.yaml
+++ b/.github/workflows/validate-devfiles-minikube.yaml
@@ -36,6 +36,6 @@ jobs:
       uses: redhat-actions/openshift-tools-installer@v1
       with:
         # Installs the latest release of odo
-        odo: "latest"
+        odo: "2.5.1"
     - name: Validate the devfile stacks
       run: tests/test.sh odo


### PR DESCRIPTION
Don't use the odo v3-alpha binary. Stay on odo v2.x until the scripts are updated by the odo team to support odo v3.