### PR TITLE
Update the schema version to 2.1.0

### DIFF
--- a/stacks/go/devfile.yaml
+++ b/stacks/go/devfile.yaml
@@ -1,4 +1,4 @@
-schemaVersion: 2.0.0
+schemaVersion: 2.1.0
 metadata:
   description: Stack with the latest Go version
   displayName: Go Runtime

--- a/stacks/java-maven/devfile.yaml
+++ b/stacks/java-maven/devfile.yaml
@@ -1,4 +1,4 @@
-schemaVersion: 2.0.0
+schemaVersion: 2.1.0
 metadata:
   name: java-maven
   version: 1.1.0

--- a/stacks/java-quarkus/devfile.yaml
+++ b/stacks/java-quarkus/devfile.yaml
@@ -1,4 +1,4 @@
-schemaVersion: 2.0.0
+schemaVersion: 2.1.0
 metadata:
   name: java-quarkus
   version: 1.1.0

--- a/stacks/java-springboot/devfile.yaml
+++ b/stacks/java-springboot/devfile.yaml
@@ -1,4 +1,4 @@
-schemaVersion: 2.0.0
+schemaVersion: 2.1.0
 metadata:
   name: java-springboot
   version: 1.1.0

--- a/stacks/java-vertx/devfile.yaml
+++ b/stacks/java-vertx/devfile.yaml
@@ -1,4 +1,4 @@
-schemaVersion: 2.0.0
+schemaVersion: 2.1.0
 metadata:
   name: java-vertx
   version: 1.1.0

--- a/stacks/java-wildfly-bootable-jar/devfile.yaml
+++ b/stacks/java-wildfly-bootable-jar/devfile.yaml
@@ -1,4 +1,4 @@
-schemaVersion: 2.0.0
+schemaVersion: 2.1.0
 metadata:
   name: java-wildfly-bootable-jar
   version: 1.0.5

--- a/stacks/java-wildfly/devfile.yaml
+++ b/stacks/java-wildfly/devfile.yaml
@@ -1,4 +1,4 @@
-schemaVersion: 2.0.0
+schemaVersion: 2.1.0
 metadata:
   name: java-wildfly
   version: 1.0.5

--- a/stacks/nodejs/devfile.yaml
+++ b/stacks/nodejs/devfile.yaml
@@ -1,4 +1,4 @@
-schemaVersion: 2.0.0
+schemaVersion: 2.1.0
 metadata:
   name: nodejs
   version: 1.0.1

--- a/stacks/php-laravel/devfile.yaml
+++ b/stacks/php-laravel/devfile.yaml
@@ -1,4 +1,4 @@
-schemaVersion: 2.0.0
+schemaVersion: 2.1.0
 metadata:
   description: Stack with Laravel 8
   displayName: Laravel

--- a/stacks/python-django/devfile.yaml
+++ b/stacks/python-django/devfile.yaml
@@ -1,4 +1,4 @@
-schemaVersion: 2.0.0
+schemaVersion: 2.1.0
 metadata:
   name: python-django
   version: 1.0.0

--- a/stacks/python/devfile.yaml
+++ b/stacks/python/devfile.yaml
@@ -1,4 +1,4 @@
-schemaVersion: 2.0.0
+schemaVersion: 2.1.0
 metadata:
   name: python
   version: 1.0.0


### PR DESCRIPTION
Updates all 2.0.0 devfiles to 2.1.0

This is because when trying to implement `variables` into the devfile,
it does not work with 2.0.0 and our `odo` implementaiton.

https://github.com/redhat-developer/odo/issues/5719

- [X] Contributing guide
_Have you read the [devfile registry contributing guide](https://github.com/devfile/registry/blob/main/CONTRIBUTING.md) and followed its instructions?_
- [X] Test automation
_Does this repository's tests pass with your changes?_
- [X] Documentation
_Does any documentation need to be updated with your changes?_
- [X] Check Tools Provider
_Have you tested the changes with existing tools, i.e. Odo, Che, Console? (See [devfile registry contributing guide](https://github.com/devfile/registry/blob/main/CONTRIBUTING.md) on how to test changes)_

Signed-off-by: Charlie Drage <charlie@charliedrage.com>