### PR TITLE
feat: Adding stack with minimal Devfile that only contains metadata fields and the schema version

### DIFF
--- a/stacks/empty/OWNERS
+++ b/stacks/empty/OWNERS
@@ -1,0 +1,5 @@
+# See the OWNERS docs: https://go.k8s.io/owners
+
+reviewers:
+- kadel
+- l0rd

--- a/stacks/empty/devfile.yaml
+++ b/stacks/empty/devfile.yaml
@@ -1,0 +1,7 @@
+schemaVersion: 2.2.0
+metadata:
+  name: empty
+  version: 1.0.0
+  displayName: Empty Devfile
+  description: Stack with minimal Devfile that only contains metadata fields and the schema version
+  icon: https://raw.githubusercontent.com/devfile/devfile.github.io/master/images/devfileLogo.svg


### PR DESCRIPTION
Signed-off-by: Ilya Buziuk <ibuziuk@redhat.com>

### What does this PR do?:
Adding stack with minimal Devfile that only contains metadata fields and the schema version.
For Eclipse Che / Dev Spaces that devfile can be used for starting a workspace without any projects cloned. 

### Which issue(s) this PR fixes:
Related to https://github.com/eclipse/che/issues/21554

### PR acceptance criteria:

- [ ] Contributing guide
_Have you read the [devfile registry contributing guide](https://github.com/devfile/registry/blob/main/CONTRIBUTING.md) and followed its instructions?_
- [ ] Test automation
_Does this repository's tests pass with your changes?_
- [ ] Documentation
_Does any documentation need to be updated with your changes?_
- [ ] Check Tools Provider
_Have you tested the changes with existing tools, i.e. Odo, Che, Console? (See [devfile registry contributing guide](https://github.com/devfile/registry/blob/main/CONTRIBUTING.md) on how to test changes)_


### How to test changes / Special notes to the reviewer:

The build is currently failing with `Error: failed to generate index struct: /build/stacks/empty devfile is not valid: [metadata.language is not set metadata.projectType is not set]` but the question is do we really want to enforce the language and the projectType ?