### PR TITLE
use more up-to-date images for java-maven and java-springboot

### DIFF
--- a/stacks/java-maven/devfile.yaml
+++ b/stacks/java-maven/devfile.yaml
@@ -19,6 +19,7 @@ components:
   - name: tools
     container:
       image: registry.access.redhat.com/ubi8/openjdk-11:latest
+      command: ["tail", "-f", "/dev/null"]
       memoryLimit: 512Mi
       mountSources: true
       endpoints:

--- a/stacks/java-maven/devfile.yaml
+++ b/stacks/java-maven/devfile.yaml
@@ -1,7 +1,7 @@
 schemaVersion: 2.1.0
 metadata:
   name: java-maven
-  version: 1.1.1
+  version: 1.2.0
   displayName: Maven Java
   description: Upstream Maven and OpenJDK 11
   tags:
@@ -18,7 +18,7 @@ starterProjects:
 components:
   - name: tools
     container:
-      image: quay.io/eclipse/che-java11-maven:next
+      image: registry.access.redhat.com/ubi8/openjdk-11:latest
       memoryLimit: 512Mi
       mountSources: true
       endpoints:

--- a/stacks/java-springboot/devfile.yaml
+++ b/stacks/java-springboot/devfile.yaml
@@ -20,6 +20,7 @@ components:
   - name: tools
     container:
       image: registry.access.redhat.com/ubi8/openjdk-11:latest
+      command: ["tail", "-f", "/dev/null"]
       memoryLimit: 768Mi
       mountSources: true
       endpoints:

--- a/stacks/java-springboot/devfile.yaml
+++ b/stacks/java-springboot/devfile.yaml
@@ -1,7 +1,7 @@
 schemaVersion: 2.1.0
 metadata:
   name: java-springboot
-  version: 1.1.1
+  version: 1.2.0
   displayName: Spring Boot®
   description: Spring Boot® using Java
   tags:
@@ -19,7 +19,7 @@ starterProjects:
 components:
   - name: tools
     container:
-      image: quay.io/eclipse/che-java11-maven:next
+      image: registry.access.redhat.com/ubi8/openjdk-11:latest
       memoryLimit: 768Mi
       mountSources: true
       endpoints:


### PR DESCRIPTION
### What does this PR do?:
use registry.access.redhat.com/ubi8/openjdk-11:latest for java-maven and java-springboot stacks


It looks like the original image are not maintained anymore. Last update was more than 8 months ago (nightly tag), and they have Critical vulnerabilities (quay scanner shows 84 Critical-level vulnerabilities.)

### Which issue(s) this PR fixes:

### PR acceptance criteria:

- [x] Contributing guide
_Have you read the [devfile registry contributing guide](https://github.com/devfile/registry/blob/main/CONTRIBUTING.md) and followed its instructions?_
- [x] Test automation
_Does this repository's tests pass with your changes?_
- [ ] Documentation
_Does any documentation need to be updated with your changes?_
- [x] Check Tools Provider
_Have you tested the changes with existing tools, i.e. Odo, Che, Console? (See [devfile registry contributing guide](https://github.com/devfile/registry/blob/main/CONTRIBUTING.md) on how to test changes)_


### How to test changes / Special notes to the reviewer: