### PR TITLE
Fix missing `DEBUG_PORT` environment variable in Node.JS stack

### DIFF
--- a/stacks/nodejs/devfile.yaml
+++ b/stacks/nodejs/devfile.yaml
@@ -23,6 +23,9 @@ components:
       args: ['tail', '-f', '/dev/null']
       memoryLimit: 1024Mi
       mountSources: true
+      env:
+        - name: DEBUG_PORT
+          value: '5858'
       endpoints:
         - name: http-node
           targetPort: 3000

--- a/stacks/nodejs/devfile.yaml
+++ b/stacks/nodejs/devfile.yaml
@@ -1,7 +1,7 @@
 schemaVersion: 2.1.0
 metadata:
   name: nodejs
-  version: 2.1.0
+  version: 2.1.1
   displayName: Node.js Runtime
   description: Stack with Node.js 16
   icon: https://nodejs.org/static/images/logos/nodejs-new-pantone-black.svg


### PR DESCRIPTION
### What does this PR do?:
This adds the missing `DEBUG_PORT` environment variable to the Node.JS stack. Otherwise, the `debug` command won't start when used with the starter project declared in this stack.
See https://github.com/devfile/api/issues/929 for more details.

### Which issue(s) this PR fixes:
Fixes https://github.com/devfile/api/issues/929

### PR acceptance criteria:

- [x] Contributing guide
_Have you read the [devfile registry contributing guide](https://github.com/devfile/registry/blob/main/CONTRIBUTING.md) and followed its instructions?_
- [x] Test automation
_Does this repository's tests pass with your changes?_
- [ ] Documentation
_Does any documentation need to be updated with your changes?_
- [x] Check Tools Provider
_Have you tested the changes with existing tools, i.e. Odo, Che, Console? (See [devfile registry contributing guide](https://github.com/devfile/registry/blob/main/CONTRIBUTING.md) on how to test changes)_

### How to test changes / Special notes to the reviewer:
I manually ran the `tests/test.sh` script (using odo 2.5.1) against both Minikube and OpenShift clusters.