### PR TITLE
Declare missing debug endpoints

### DIFF
--- a/stacks/java-maven/devfile.yaml
+++ b/stacks/java-maven/devfile.yaml
@@ -24,6 +24,9 @@ components:
       endpoints:
         - name: http-maven
           targetPort: 8080
+        - exposure: none
+          name: debug
+          targetPort: 5858
       volumeMounts:
         - name: m2
           path: /home/user/.m2

--- a/stacks/java-maven/devfile.yaml
+++ b/stacks/java-maven/devfile.yaml
@@ -1,7 +1,7 @@
 schemaVersion: 2.1.0
 metadata:
   name: java-maven
-  version: 1.1.1
+  version: 1.2.0
   displayName: Maven Java
   description: Upstream Maven and OpenJDK 11
   tags:

--- a/stacks/java-openliberty-gradle/devfile.yaml
+++ b/stacks/java-openliberty-gradle/devfile.yaml
@@ -18,8 +18,8 @@
 schemaVersion: 2.1.0
 metadata:
   name: java-openliberty-gradle
-  version: 0.3.1
-  displayName: Open Liberty Gradle
+  version: 0.4.0
+  displayName: 'Open Liberty Gradle'
   description: Java application Gradle-built stack using the Open Liberty runtime
   icon: https://raw.githubusercontent.com/OpenLiberty/logos/7fbb132949b9b2589e18c8d5665c1b107028a21d/logomark/svg/OL_logomark.svg
   tags:

--- a/stacks/java-openliberty-gradle/devfile.yaml
+++ b/stacks/java-openliberty-gradle/devfile.yaml
@@ -55,6 +55,9 @@ components:
           name: http-gradle
           targetPort: 9080
           protocol: http
+        - exposure: none
+          name: debug
+          targetPort: 5858
       env:
         - name: DEBUG_PORT
           value: '5858'

--- a/stacks/java-openliberty/devfile.yaml
+++ b/stacks/java-openliberty/devfile.yaml
@@ -57,6 +57,9 @@ components:
           name: http-openlib
           targetPort: 9080
           protocol: http
+        - exposure: none
+          name: debug
+          targetPort: 5858
       env:
         - name: DEBUG_PORT
           value: '5858'

--- a/stacks/java-openliberty/devfile.yaml
+++ b/stacks/java-openliberty/devfile.yaml
@@ -18,8 +18,8 @@
 schemaVersion: 2.1.0
 metadata:
   name: java-openliberty
-  version: 0.8.1
-  displayName: Open Liberty Maven
+  version: 0.9.0
+  displayName: 'Open Liberty Maven'
   description: Java application Maven-built stack using the Open Liberty runtime
   icon: https://raw.githubusercontent.com/OpenLiberty/logos/7fbb132949b9b2589e18c8d5665c1b107028a21d/logomark/svg/OL_logomark.svg
   tags:

--- a/stacks/java-quarkus/devfile.yaml
+++ b/stacks/java-quarkus/devfile.yaml
@@ -31,6 +31,9 @@ components:
       endpoints:
         - name: http-quarkus
           targetPort: 8080
+        - exposure: none
+          name: debug
+          targetPort: 5858
       env:
         - name: DEBUG_PORT
           value: '5858'

--- a/stacks/java-quarkus/devfile.yaml
+++ b/stacks/java-quarkus/devfile.yaml
@@ -1,7 +1,7 @@
 schemaVersion: 2.1.0
 metadata:
   name: java-quarkus
-  version: 1.2.1
+  version: 1.3.0
   website: https://quarkus.io
   displayName: Quarkus Java
   description: Quarkus with Java

--- a/stacks/java-springboot/devfile.yaml
+++ b/stacks/java-springboot/devfile.yaml
@@ -25,6 +25,9 @@ components:
       endpoints:
         - name: http-springboot
           targetPort: 8080
+        - exposure: none
+          name: debug
+          targetPort: 5858
       volumeMounts:
         - name: m2
           path: /home/user/.m2

--- a/stacks/java-springboot/devfile.yaml
+++ b/stacks/java-springboot/devfile.yaml
@@ -1,7 +1,7 @@
 schemaVersion: 2.1.0
 metadata:
   name: java-springboot
-  version: 1.1.1
+  version: 1.2.0
   displayName: Spring Boot®
   description: Spring Boot® using Java
   tags:

--- a/stacks/java-vertx/devfile.yaml
+++ b/stacks/java-vertx/devfile.yaml
@@ -96,6 +96,9 @@ components:
           name: http-vertx
           targetPort: 8080
           protocol: http
+        - exposure: none
+          name: debug
+          targetPort: 5858
       image: quay.io/eclipse/che-java11-maven:next
       memoryLimit: 512Mi
       mountSources: true

--- a/stacks/java-vertx/devfile.yaml
+++ b/stacks/java-vertx/devfile.yaml
@@ -1,7 +1,7 @@
 schemaVersion: 2.1.0
 metadata:
   name: java-vertx
-  version: 1.1.1
+  version: 1.2.0
   displayName: Vert.x Java
   description: Upstream Vert.x using Java
   icon: https://raw.githubusercontent.com/vertx-web-site/vertx-logo/master/vertx-logo.svg

--- a/stacks/java-websphereliberty-gradle/devfile.yaml
+++ b/stacks/java-websphereliberty-gradle/devfile.yaml
@@ -56,6 +56,9 @@ components:
           name: http-webgradle
           targetPort: 9080
           protocol: http
+        - exposure: none
+          name: debug
+          targetPort: 5858
       env:
         - name: DEBUG_PORT
           value: '5858'

--- a/stacks/java-websphereliberty-gradle/devfile.yaml
+++ b/stacks/java-websphereliberty-gradle/devfile.yaml
@@ -18,8 +18,8 @@
 schemaVersion: 2.1.0
 metadata:
   name: java-websphereliberty-gradle
-  version: 0.3.1
-  displayName: WebSphere Liberty Gradle
+  version: 0.4.0
+  displayName: 'WebSphere Liberty Gradle'
   description: Java application Gradle-built stack using the WebSphere Liberty runtime
   icon: https://raw.githubusercontent.com/WASdev/logos/main/liberty-was-500-purple.svg
   tags:

--- a/stacks/java-websphereliberty/devfile.yaml
+++ b/stacks/java-websphereliberty/devfile.yaml
@@ -18,8 +18,8 @@
 schemaVersion: 2.1.0
 metadata:
   name: java-websphereliberty
-  version: 0.8.1
-  displayName: WebSphere Liberty Maven
+  version: 0.9.0
+  displayName: 'WebSphere Liberty Maven'
   description: Java application Maven-built stack using the WebSphere Liberty runtime
   icon: https://raw.githubusercontent.com/WASdev/logos/main/liberty-was-500-purple.svg
   tags:

--- a/stacks/java-websphereliberty/devfile.yaml
+++ b/stacks/java-websphereliberty/devfile.yaml
@@ -58,6 +58,9 @@ components:
           name: http-websphere
           targetPort: 9080
           protocol: http
+        - exposure: none
+          name: debug
+          targetPort: 5858
       env:
         - name: DEBUG_PORT
           value: '5858'

--- a/stacks/java-wildfly-bootable-jar/devfile.yaml
+++ b/stacks/java-wildfly-bootable-jar/devfile.yaml
@@ -133,6 +133,9 @@ components:
       endpoints:
         - name: http-wildjar
           targetPort: 8080
+        - exposure: none
+          name: debug
+          targetPort: 5858
   - name: m2-repository
     volume:
       size: 3Gi

--- a/stacks/java-wildfly-bootable-jar/devfile.yaml
+++ b/stacks/java-wildfly-bootable-jar/devfile.yaml
@@ -1,7 +1,7 @@
 schemaVersion: 2.1.0
 metadata:
   name: java-wildfly-bootable-jar
-  version: 1.0.6
+  version: 1.1.0
   website: https://docs.wildfly.org/bootablejar/
   displayName: WildFly Bootable Jar
   description: Java stack with WildFly in bootable Jar mode, OpenJDK 11 and Maven 3.5

--- a/stacks/java-wildfly/devfile.yaml
+++ b/stacks/java-wildfly/devfile.yaml
@@ -117,6 +117,9 @@ components:
       endpoints:
         - name: http-wildfly
           targetPort: 8080
+        - exposure: none
+          name: debug
+          targetPort: 5858
   - name: m2-repository
     volume:
       size: 3Gi

--- a/stacks/java-wildfly/devfile.yaml
+++ b/stacks/java-wildfly/devfile.yaml
@@ -1,7 +1,7 @@
 schemaVersion: 2.1.0
 metadata:
   name: java-wildfly
-  version: 1.0.6
+  version: 1.1.0
   website: https://wildfly.org
   displayName: WildFly Java
   description: Upstream WildFly

--- a/stacks/nodejs/devfile.yaml
+++ b/stacks/nodejs/devfile.yaml
@@ -1,7 +1,7 @@
 schemaVersion: 2.1.0
 metadata:
   name: nodejs
-  version: 2.0.1
+  version: 2.1.0
   displayName: Node.js Runtime
   description: Stack with Node.js 16
   icon: https://nodejs.org/static/images/logos/nodejs-new-pantone-black.svg

--- a/stacks/nodejs/devfile.yaml
+++ b/stacks/nodejs/devfile.yaml
@@ -26,6 +26,9 @@ components:
       endpoints:
         - name: http-node
           targetPort: 3000
+        - exposure: none
+          name: debug
+          targetPort: 5858
 commands:
   - id: install
     exec:

--- a/stacks/python-django/devfile.yaml
+++ b/stacks/python-django/devfile.yaml
@@ -1,7 +1,7 @@
 schemaVersion: 2.1.0
 metadata:
   name: python-django
-  version: 2.0.1
+  version: 2.1.0
   displayName: Django
   description:
     'Django is a high-level Python web framework that enables rapid development of secure and maintainable websites.

--- a/stacks/python-django/devfile.yaml
+++ b/stacks/python-django/devfile.yaml
@@ -29,6 +29,9 @@ components:
       endpoints:
         - name: http-django
           targetPort: 8000
+        - exposure: none
+          name: debug
+          targetPort: 5858
       env:
         - name: DEBUG_PORT
           value: '5858'

--- a/stacks/python/devfile.yaml
+++ b/stacks/python/devfile.yaml
@@ -13,7 +13,7 @@ metadata:
     - Python
     - Pip
     - Flask
-  version: 2.0.2
+  version: 2.1.0
 starterProjects:
   - name: flask-example
     description:

--- a/stacks/python/devfile.yaml
+++ b/stacks/python/devfile.yaml
@@ -31,6 +31,9 @@ components:
       endpoints:
         - name: http-python
           targetPort: 8080
+        - exposure: none
+          name: debug
+          targetPort: 5858
       env:
         - name: DEBUG_PORT
           value: '5858'


### PR DESCRIPTION
### What does this PR do?:
This adds missing debug endpoints in Devfiles where a debug command is declared and expected to be listening on the debug port (injected via the `DEBUG_PORT` environment variable).
This is required in tools like `odo`, so the endpoint can be detected and port-forwarded using `odo dev --debug`. See https://github.com/redhat-developer/odo/issues/5988
I've tested this in other tools like Dev Spaces, where I noticed that some of the Devfiles used there are already declaring such endpoints, e.g.: https://github.com/devspaces-samples/quarkus-quickstarts/blob/devspaces-3-rhel-8/devfile.yaml#L12-L15

### Which issue(s) this PR fixes:
Fixes https://github.com/redhat-developer/odo/issues/5988

### PR acceptance criteria:

- [x] Contributing guide
_Have you read the [devfile registry contributing guide](https://github.com/devfile/registry/blob/main/CONTRIBUTING.md) and followed its instructions?_
- [x] Test automation
_Does this repository's tests pass with your changes?_
- [ ] Documentation
_Does any documentation need to be updated with your changes?_
- [x] Check Tools Provider
_Have you tested the changes with existing tools, i.e. Odo, Che, Console? (See [devfile registry contributing guide](https://github.com/devfile/registry/blob/main/CONTRIBUTING.md) on how to test changes)_


### How to test changes / Special notes to the reviewer:
I manually ran the `tests/test.sh` script (using `odo` 2.5.1) against both Minikube and OpenShift clusters. I had to adapt the logic that calls `odo url create` to dynamically find the endpoints ports, instead of hardcoding for some stacks, or letting `odo` determine the port (which it would not be able to do because we may now have multiple endpoints).