### PR TITLE
Use proper API version for templates

### DIFF
--- a/.ci/deploy/devfile-registry.yaml
+++ b/.ci/deploy/devfile-registry.yaml
@@ -13,7 +13,7 @@
 #   See the License for the specific language governing permissions and
 #   limitations under the License.
 ---
-apiVersion: v1
+apiVersion: template.openshift.io/v1
 kind: Template
 metadata:
   name: devfile-registry

--- a/.ci/deploy/route.yaml
+++ b/.ci/deploy/route.yaml
@@ -13,7 +13,7 @@
 #   See the License for the specific language governing permissions and
 #   limitations under the License.
 ---
-apiVersion: v1
+apiVersion: template.openshift.io/v1
 kind: Template
 metadata:
   name: devfile-registry


### PR DESCRIPTION
Need to use template.openshift.io/v1 instead of v1 for OpenShift templates