### PR TITLE
Updated the names of the starter project

### DIFF
--- a/stacks/dotnet50/devfile.yaml
+++ b/stacks/dotnet50/devfile.yaml
@@ -11,7 +11,7 @@ metadata:
   version: 1.0.1
 
 starterProjects:
-  - name: s2i-example
+  - name: dotnet-example
     git:
       checkoutFrom:
         remote: origin

--- a/stacks/dotnet60/devfile.yaml
+++ b/stacks/dotnet60/devfile.yaml
@@ -11,7 +11,7 @@ metadata:
   version: 1.0.0
 
 starterProjects:
-  - name: s2i-example
+  - name: dotnet-example
     git:
       checkoutFrom:
         remote: origin

--- a/stacks/dotnetcore31/devfile.yaml
+++ b/stacks/dotnetcore31/devfile.yaml
@@ -11,7 +11,7 @@ metadata:
   version: 1.0.1
 
 starterProjects:
-  - name: dotnet-example
+  - name: dotnetcore-example
     git:
       checkoutFrom:
         remote: origin

--- a/stacks/dotnetcore31/devfile.yaml
+++ b/stacks/dotnetcore31/devfile.yaml
@@ -11,7 +11,7 @@ metadata:
   version: 1.0.1
 
 starterProjects:
-  - name: s2i-example
+  - name: dotnet-example
     git:
       checkoutFrom:
         remote: origin


### PR DESCRIPTION
### What does this PR do?:
I have changed the starterProjects name from s2i-example to dotnet-example and dotnetcore-example in order to avoid confusion as requested.

### Which issue(s) this PR fixes:
https://github.com/devfile/api/issues/676#issue-1052735689
In addition to this issue, I have also changed the starterProjects name in the dot net core yaml file from s2i-example to dotnetcore-example.

### PR acceptance criteria:

- [ Yes] Contributing guide
_Have you read the [devfile registry contributing guide](https://github.com/devfile/registry/blob/main/CONTRIBUTING.md) and followed its instructions?_
-Since it's just updating the name of the starter project example, I didn't test the changes in Che as there is no change in the yaml files format.


### How to test changes / Special notes to the reviewer:
I am new to this, please feel free to drop some advice if I made some mistake anywhere.