### PR TITLE
increase timeout in check_non_terminating tests and update image in java-quarkus to java 17

### DIFF
--- a/stacks/java-quarkus/devfile.yaml
+++ b/stacks/java-quarkus/devfile.yaml
@@ -19,7 +19,7 @@ starterProjects:
 components:
   - name: tools
     container:
-      image: registry.access.redhat.com/ubi8/openjdk-11
+      image: registry.access.redhat.com/ubi8/openjdk-17
       args: ["tail", "-f", "/dev/null"]
       memoryLimit: 512Mi ## default app nowhere needs this but leaving room for expansion.
       mountSources: true

--- a/stacks/java-quarkus/devfile.yaml
+++ b/stacks/java-quarkus/devfile.yaml
@@ -1,7 +1,7 @@
 schemaVersion: 2.1.0
 metadata:
   name: java-quarkus
-  version: 1.1.0
+  version: 1.2.0
   website: https://quarkus.io
   displayName: Quarkus Java
   description: Quarkus with Java

--- a/tests/check_non_terminating.sh
+++ b/tests/check_non_terminating.sh
@@ -76,7 +76,7 @@ isNonTerminating() {
     _int_command=("$2")
     _int_command_args=("$3")
 
-    timeout_in_sec=180 # <== includes image pulling
+    timeout_in_sec=240 # <== includes image pulling
 
     echo "  PARAMS: image --> $_int_image, command --> ${_int_command[*]}, args --> ${_int_command_args[*]}"
  

--- a/tests/check_non_terminating.sh
+++ b/tests/check_non_terminating.sh
@@ -76,7 +76,7 @@ isNonTerminating() {
     _int_command=("$2")
     _int_command_args=("$3")
 
-    timeout_in_sec=60 # <== includes image pulling
+    timeout_in_sec=120 # <== includes image pulling
 
     echo "  PARAMS: image --> $_int_image, command --> ${_int_command[*]}, args --> ${_int_command_args[*]}"
  

--- a/tests/check_non_terminating.sh
+++ b/tests/check_non_terminating.sh
@@ -76,7 +76,7 @@ isNonTerminating() {
     _int_command=("$2")
     _int_command_args=("$3")
 
-    timeout_in_sec=120 # <== includes image pulling
+    timeout_in_sec=180 # <== includes image pulling
 
     echo "  PARAMS: image --> $_int_image, command --> ${_int_command[*]}, args --> ${_int_command_args[*]}"
  


### PR DESCRIPTION
### What does this PR do?:

### Which issue(s) this PR fixes:
fixes https://github.com/devfile/api/issues/949

this PR also increases timeout for pulling images in `check_non_terminating.sh`, there was a few failures with `icr.io/appcafe/open-liberty-devfile-stack:22.0.0.1-gradle` image that were caused only because the image was not downloaded in time.


### PR acceptance criteria:

- [x] Contributing guide
_Have you read the [devfile registry contributing guide](https://github.com/devfile/registry/blob/main/CONTRIBUTING.md) and followed its instructions?_
- [x] Test automation
_Does this repository's tests pass with your changes?_
- [ ] Documentation
_Does any documentation need to be updated with your changes?_
- [x] Check Tools Provider
_Have you tested the changes with existing tools, i.e. Odo, Che, Console? (See [devfile registry contributing guide](https://github.com/devfile/registry/blob/main/CONTRIBUTING.md) on how to test changes)_


### How to test changes / Special notes to the reviewer: