### PR TITLE
docs: adding min stack version support rule

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -52,6 +52,8 @@ Updating an existing devfile stack is relatively straightforward:
 1) Find the stack under the `stacks/` folder that you wish to update.
 2) Make the necessary changes to the stack, such as: updating image tags, commands, starter projects, etc.
 3) Update the version of stack, following the [semantic versioning format](https://semver.org/).
+
+    - When updating a stack with a newer version of the devfile specification (e.g., 2.1.0 -> 2.2.0), the previous version of the stack **must** be kept for a minimum of one (1) year.
 4) Test your changes:
     
     - Minimally, testing with odo (`odo create`, `odo push`, etc) is recommended, however if your Devfile is used with other tools, it's recommended to test there as well.


### PR DESCRIPTION
Signed-off-by: Michael Hoang <mhoang@redhat.com>

### What does this PR do?:
Adds a rule to the contributing guide that stacks with older devfile versions needs to be kept for a minimum of one year.

### Which issue(s) this PR fixes:
fixes https://github.com/devfile/api/issues/951

### PR acceptance criteria:

- [x] Contributing guide
_Have you read the [devfile registry contributing guide](https://github.com/devfile/registry/blob/main/CONTRIBUTING.md) and followed its instructions?_
- [ ] Test automation
_Does this repository's tests pass with your changes?_
- [x] Documentation
_Does any documentation need to be updated with your changes?_
- [ ] Check Tools Provider
_Have you tested the changes with existing tools, i.e. Odo, Che, Console? (See [devfile registry contributing guide](https://github.com/devfile/registry/blob/main/CONTRIBUTING.md) on how to test changes)_


### How to test changes / Special notes to the reviewer: