### PR TITLE
Remove .NET version number from template.

### DIFF
--- a/extraDevfileEntries.yaml
+++ b/extraDevfileEntries.yaml
@@ -65,8 +65,8 @@ samples:
     git:
       remotes:
         origin: https://github.com/devfile-samples/devfile-sample-go-basic.git
-  - name: dotnet60-basic
-    displayName: Basic .NET 6.0
+  - name: dotnet-basic
+    displayName: Basic .NET
     description: A simple application using .NET 6.0
     icon: https://github.com/dotnet/brand/raw/main/logo/dotnet-logo.png
     tags:


### PR DESCRIPTION
This is consistent with the other '.NET' items in the OpenShift catalog, and the other devfiles which also don't include a version number.

@kadel ptal.