### PR TITLE
Reverts dotnet stack projectTypes to dotnet

### DIFF
--- a/extraDevfileEntries.yaml
+++ b/extraDevfileEntries.yaml
@@ -71,7 +71,7 @@ samples:
     icon: https://github.com/dotnet/brand/raw/main/logo/dotnet-logo.png
     tags:
       - .NET
-    projectType: .NET
+    projectType: dotnet
     language: .NET
     provider: Red Hat
     git:

--- a/extraDevfileEntries.yaml
+++ b/extraDevfileEntries.yaml
@@ -33,7 +33,7 @@ samples:
     tags:
       - Java
       - Spring Boot
-    projectType: Spring Boot
+    projectType: springboot
     language: Java
     provider: Red Hat
     git:

--- a/stacks/dotnet50/devfile.yaml
+++ b/stacks/dotnet50/devfile.yaml
@@ -5,7 +5,7 @@ metadata:
   description: Stack with .NET 5.0
   icon: https://github.com/dotnet/brand/raw/main/logo/dotnet-logo.png
   language: .NET
-  projectType: .NET
+  projectType: dotnet
   tags:
     - .NET
   version: 1.0.3
@@ -22,7 +22,7 @@ components:
   - name: dotnet
     container:
       image: registry.access.redhat.com/ubi8/dotnet-50:5.0
-      args: ['tail', '-f', '/dev/null']
+      args: ["tail", "-f", "/dev/null"]
       mountSources: true
       env:
         - name: CONFIGURATION

--- a/stacks/dotnet60/devfile.yaml
+++ b/stacks/dotnet60/devfile.yaml
@@ -5,7 +5,7 @@ metadata:
   description: Stack with .NET 6.0
   icon: https://github.com/dotnet/brand/raw/main/logo/dotnet-logo.png
   language: .NET
-  projectType: .NET
+  projectType: dotnet
   tags:
     - .NET
   version: 1.0.2
@@ -22,7 +22,7 @@ components:
   - name: dotnet
     container:
       image: registry.access.redhat.com/ubi8/dotnet-60:6.0
-      args: ['tail', '-f', '/dev/null']
+      args: ["tail", "-f", "/dev/null"]
       mountSources: true
       env:
         - name: CONFIGURATION

--- a/stacks/dotnetcore31/devfile.yaml
+++ b/stacks/dotnetcore31/devfile.yaml
@@ -5,7 +5,7 @@ metadata:
   description: Stack with .NET Core 3.1
   icon: https://github.com/dotnet/brand/raw/main/logo/dotnet-logo.png
   language: .NET
-  projectType: .NET
+  projectType: dotnet
   tags:
     - .NET
   version: 1.0.3
@@ -22,7 +22,7 @@ components:
   - name: dotnet
     container:
       image: registry.access.redhat.com/ubi8/dotnet-31:3.1
-      args: ['tail', '-f', '/dev/null']
+      args: ["tail", "-f", "/dev/null"]
       mountSources: true
       env:
         - name: CONFIGURATION

--- a/stacks/java-springboot/devfile.yaml
+++ b/stacks/java-springboot/devfile.yaml
@@ -9,13 +9,13 @@ metadata:
     - Spring Boot
   globalMemoryLimit: 2674Mi
   icon: https://spring.io/images/projects/spring-edf462fec682b9d48cf628eaf9e19521.svg
-  projectType: Spring Boot
+  projectType: springboot
   language: Java
 starterProjects:
   - name: springbootproject
     git:
       remotes:
-        origin: 'https://github.com/odo-devfiles/springboot-ex.git'
+        origin: "https://github.com/odo-devfiles/springboot-ex.git"
 components:
   - name: tools
     container:
@@ -30,7 +30,7 @@ components:
           path: /home/user/.m2
       env:
         - name: DEBUG_PORT
-          value: '5858'
+          value: "5858"
   - name: m2
     volume:
       size: 3Gi
@@ -39,7 +39,7 @@ commands:
     exec:
       component: tools
       workingDir: ${PROJECT_SOURCE}
-      commandLine: 'mvn clean -Dmaven.repo.local=/home/user/.m2/repository package -Dmaven.test.skip=true'
+      commandLine: "mvn clean -Dmaven.repo.local=/home/user/.m2/repository package -Dmaven.test.skip=true"
       group:
         kind: build
         isDefault: true
@@ -47,7 +47,7 @@ commands:
     exec:
       component: tools
       workingDir: ${PROJECT_SOURCE}
-      commandLine: 'mvn -Dmaven.repo.local=/home/user/.m2/repository spring-boot:run'
+      commandLine: "mvn -Dmaven.repo.local=/home/user/.m2/repository spring-boot:run"
       group:
         kind: run
         isDefault: true
@@ -55,7 +55,7 @@ commands:
     exec:
       component: tools
       workingDir: ${PROJECT_SOURCE}
-      commandLine: 'java -Xdebug -Xrunjdwp:server=y,transport=dt_socket,address=${DEBUG_PORT},suspend=n -jar target/*.jar'
+      commandLine: "java -Xdebug -Xrunjdwp:server=y,transport=dt_socket,address=${DEBUG_PORT},suspend=n -jar target/*.jar"
       group:
         kind: debug
         isDefault: true


### PR DESCRIPTION
### What does this PR do?:

Reverted dotnet stack projectTypes to dotnet

### Which issue(s) this PR fixes:

related https://github.com/redhat-developer/odo/issues/6234

### PR acceptance criteria:

- [ ] Contributing guide
_Have you read the [devfile registry contributing guide](https://github.com/devfile/registry/blob/main/CONTRIBUTING.md) and followed its instructions?_
- [ ] Test automation
_Does this repository's tests pass with your changes?_
- [ ] Documentation
_Does any documentation need to be updated with your changes?_
- [ ] Check Tools Provider
_Have you tested the changes with existing tools, i.e. Odo, Che, Console? (See [devfile registry contributing guide](https://github.com/devfile/registry/blob/main/CONTRIBUTING.md) on how to test changes)_


### How to test changes / Special notes to the reviewer: