### PR TITLE
finding nested devfiles in stack validation test

### DIFF
--- a/tests/check_non_terminating.sh
+++ b/tests/check_non_terminating.sh
@@ -113,9 +113,13 @@ isNonTerminating() {
 YQ_PATH=${YQ_PATH:-yq}
 TEST_NAMESPACE=${TEST_NAMESPACE:-default}
 
-find "$DEVFILES_DIR" -maxdepth 1 -type d ! -path "$DEVFILES_DIR" -print0 | while IFS= read -r -d '' devfile_dir; do
+find "$DEVFILES_DIR" -maxdepth 2 -type d ! -path "$DEVFILES_DIR" -print0 | while IFS= read -r -d '' devfile_dir; do
 
     devfile_path=$devfile_dir/devfile.yaml
+    if [ ! -f "$devfile_path" ]; then
+        # multi version stacks contain nested devfiles
+        continue
+    fi
 
     echo "======================="
     echo "Testing ${devfile_path}"

--- a/tests/check_odov3.sh
+++ b/tests/check_odov3.sh
@@ -3,20 +3,20 @@
 set -x
 
 ginkgo run --procs 2 \
-  --skip="stack: java-openliberty-gradle starter: rest" \
-  --skip="stack: java-vertx starter: vertx-cache-example-redhat" \
-  --skip="stack: java-vertx starter: vertx-cache-example" \
-  --skip="stack: java-vertx starter: vertx-circuit-breaker-example-redhat" \
-  --skip="stack: java-vertx starter: vertx-circuit-breaker-example" \
-  --skip="stack: java-vertx starter: vertx-crud-example-redhat" \
-  --skip="stack: java-vertx starter: vertx-crud-example" \
-  --skip="stack: java-vertx starter: vertx-http-example-redhat" \
-  --skip="stack: java-vertx starter: vertx-istio-circuit-breaker-booster" \
-  --skip="stack: java-vertx starter: vertx-istio-distributed-tracing-booster" \
-  --skip="stack: java-vertx starter: vertx-istio-routing-booster" \
-  --skip="stack: java-vertx starter: vertx-istio-security-booster" \
-  --skip="stack: java-vertx starter: vertx-messaging-work-queue-booster" \
-  --skip="stack: java-websphereliberty-gradle starter: rest" \
+  --skip="stack: java-openliberty-gradle version: 0.4.0 starter: rest" \
+  --skip="stack: java-vertx version: 1.2.0 starter: vertx-cache-example-redhat" \
+  --skip="stack: java-vertx version: 1.2.0 starter: vertx-cache-example" \
+  --skip="stack: java-vertx version: 1.2.0 starter: vertx-circuit-breaker-example-redhat" \
+  --skip="stack: java-vertx version: 1.2.0 starter: vertx-circuit-breaker-example" \
+  --skip="stack: java-vertx version: 1.2.0 starter: vertx-crud-example-redhat" \
+  --skip="stack: java-vertx version: 1.2.0 starter: vertx-crud-example" \
+  --skip="stack: java-vertx version: 1.2.0 starter: vertx-http-example-redhat" \
+  --skip="stack: java-vertx version: 1.2.0 starter: vertx-istio-circuit-breaker-booster" \
+  --skip="stack: java-vertx version: 1.2.0 starter: vertx-istio-distributed-tracing-booster" \
+  --skip="stack: java-vertx version: 1.2.0 starter: vertx-istio-routing-booster" \
+  --skip="stack: java-vertx version: 1.2.0 starter: vertx-istio-security-booster" \
+  --skip="stack: java-vertx version: 1.2.0 starter: vertx-messaging-work-queue-booster" \
+  --skip="stack: java-websphereliberty-gradle version: 0.4.0 starter: rest" \
   --skip="stack: java-wildfly-bootable-jar" \
   --skip="stack: java-wildfly" \
   --skip="stack: java-openliberty" \

--- a/tests/odov3/odo_test.go
+++ b/tests/odov3/odo_test.go
@@ -67,6 +67,8 @@ func createStack(fileName string, path string) (Stack, error) {
 		return Stack{}, err
 	}
 
+	stack.version = devfile.Data.GetMetadata().Version
+
 	stack.starterProjects, err = devfile.Data.GetStarterProjects(common.DevfileOptions{})
 	if err != nil {
 		return Stack{}, err
@@ -190,7 +192,7 @@ var _ = Describe("test starter projects from devfile stacks", func() {
 		for _, starterProject := range stack.starterProjects {
 			stack := stack
 			starterProject := starterProject
-			It(fmt.Sprintf("stack: %s starter: %s", stack.id, starterProject.Name), func() {
+			It(fmt.Sprintf("stack: %s version: %s starter: %s", stack.id, stack.version, starterProject.Name), func() {
 
 				_, _, err := runOdo("init", "--devfile-path", stack.devfilePath, "--starter", starterProject.Name, "--name", starterProject.Name)
 				Expect(err).To(BeNil())

--- a/tests/odov3/types.go
+++ b/tests/odov3/types.go
@@ -35,5 +35,18 @@ type Stack struct {
 	starterProjects []v1alpha2.StarterProject
 }
 
+type StackInfo struct {
+	Name        string    `yaml:"name,omitempty"`
+	DisplayName string    `yaml:"displayName,omitempty"`
+	Description string    `yaml:"description,omitempty"`
+	Icon        string    `yaml:"icon,omitempty"`
+	Versions    []Version `yaml:"versions,omitempty"`
+}
+
+type Version struct {
+	Version string `yaml:"version,omitempty"`
+	Default bool   `yaml:"default,omitempty"`
+}
+
 type RunningMode string
 type RunningModes map[RunningMode]bool

--- a/tests/odov3/types.go
+++ b/tests/odov3/types.go
@@ -31,6 +31,7 @@ type ForwardedPort struct {
 
 type Stack struct {
 	id              string
+	version         string
 	devfilePath     string
 	starterProjects []v1alpha2.StarterProject
 }


### PR DESCRIPTION
Signed-off-by: Michael Hoang <mhoang@redhat.com>

### What does this PR do?:
_Summarize the changes. Are any stacks or samples added or updated?_

Updates the CI tests to support stacks with multiple versions. 

### Which issue(s) this PR fixes:
_Link to github issue(s)_

related to https://github.com/devfile/api/issues/757

### PR acceptance criteria:

- [x] Contributing guide
_Have you read the [devfile registry contributing guide](https://github.com/devfile/registry/blob/main/CONTRIBUTING.md) and followed its instructions?_
- [x] Test automation
_Does this repository's tests pass with your changes?_
- [ ] Documentation
_Does any documentation need to be updated with your changes?_
- [ ] Check Tools Provider
_Have you tested the changes with existing tools, i.e. Odo, Che, Console? (See [devfile registry contributing guide](https://github.com/devfile/registry/blob/main/CONTRIBUTING.md) on how to test changes)_


### How to test changes / Special notes to the reviewer:

Currently the devfile paths are assumed to be in the root level of the stack.

```
stacks
├── stack1
│   └── devfile.yaml
└── stack2
    └── devfile.yaml
```

Whereas a multi version stack will have nested devfiles.

```
stacks
    ├── stack1
    │   ├── 1.0.0
    │   │   └── devfile.yaml
    │   ├── 2.0.0
    │   │   └── devfile.yaml
    │   └── stack.yaml
    └── stack2
        └── devfile.yaml

```