### PR TITLE
Halt updates from `devfile-index-base`

### DIFF
--- a/.ci/Dockerfile
+++ b/.ci/Dockerfile
@@ -29,6 +29,6 @@ RUN git clone https://github.com/devfile/registry-support.git /registry-support
 # Run the registry build tools
 RUN /registry-support/build-tools/build.sh /registry /build
 
-FROM quay.io/devfile/devfile-index-base:next
+FROM quay.io/devfile/devfile-index-base@sha256:6270b58f53a9805f0e8ebb340ea2e9b16a1b53bfb5f9a9a0ab0de79c152c9e76
 
 COPY --from=builder /build /registry


### PR DESCRIPTION
Signed-off-by: Michael Valdron <mvaldron@redhat.com>

### What does this PR do?:

This change is to temporarily disable updates from `devfile-index-base:next` built under [registry-support](https://github.com/devfile/registry-support) until deployment is ready for the new build process.

_Summarize the changes. Are any stacks or samples added or updated?_

Image reference to `devfile-index-base` has been changed to stay on the current digest instead of using the image tag `next`.

### Which issue(s) this PR fixes:
_Link to github issue(s)_

part of devfile/api#747

### PR acceptance criteria:

- [ ] Contributing guide
_Have you read the [devfile registry contributing guide](https://github.com/devfile/registry/blob/main/CONTRIBUTING.md) and followed its instructions?_
- [ ] Test automation
_Does this repository's tests pass with your changes?_
- [ ] Documentation
_Does any documentation need to be updated with your changes?_
- [ ] Check Tools Provider
_Have you tested the changes with existing tools, i.e. Odo, Che, Console? (See [devfile registry contributing guide](https://github.com/devfile/registry/blob/main/CONTRIBUTING.md) on how to test changes)_


### How to test changes / Special notes to the reviewer: