### PR TITLE
pre pulling images for minikube tests

### DIFF
--- a/.github/workflows/validate-stacks.yaml
+++ b/.github/workflows/validate-stacks.yaml
@@ -28,7 +28,7 @@ concurrency:
   cancel-in-progress: true
 
 env:
-  MINIKUBE_VERSION: "v1.27.0"
+  MINIKUBE_VERSION: "v1.29.0"
   KUBERNETES_VERSION: "v1.25.2"
   TEST_DELTA: false
 
@@ -67,7 +67,7 @@ jobs:
           fetch-depth: 0
 
       - name: Setup Minikube
-        uses: manusa/actions-setup-minikube@v2.7.0
+        uses: manusa/actions-setup-minikube@v2.7.2
         with:
           minikube version: ${{ env.MINIKUBE_VERSION }}
           kubernetes version: ${{ env.KUBERNETES_VERSION }}
@@ -92,7 +92,7 @@ jobs:
           fetch-depth: 0
 
       - name: Setup Minikube
-        uses: manusa/actions-setup-minikube@v2.7.0
+        uses: manusa/actions-setup-minikube@v2.7.2
         with:
           minikube version: ${{ env.MINIKUBE_VERSION }}
           kubernetes version: ${{ env.KUBERNETES_VERSION }}
@@ -125,7 +125,7 @@ jobs:
           fetch-depth: 0
 
       - name: Setup Minikube
-        uses: manusa/actions-setup-minikube@v2.7.0
+        uses: manusa/actions-setup-minikube@v2.7.2
         with:
           minikube version: ${{ env.MINIKUBE_VERSION }}
           kubernetes version: ${{ env.KUBERNETES_VERSION }}


### PR DESCRIPTION
Signed-off-by: Michael Hoang <mhoang@redhat.com>

### What does this PR do?:
The github action (`actions-setup-minikube`) for setting up minikube currently uses `cri-dockerd v0.2.3` which contains a bug where large images won't download. This is fixed in `cri-dockerd v0.2.6` but hasn't been updated in the github action yet.

This workaround pre pulls images without a timeout.

### Which issue(s) this PR fixes:
fixes https://github.com/devfile/api/issues/987

### PR acceptance criteria:

- [x] Contributing guide
_Have you read the [devfile registry contributing guide](https://github.com/devfile/registry/blob/main/CONTRIBUTING.md) and followed its instructions?_
- [x] Test automation
_Does this repository's tests pass with your changes?_
- [ ] Documentation
_Does any documentation need to be updated with your changes?_
- [ ] Check Tools Provider
_Have you tested the changes with existing tools, i.e. Odo, Che, Console? (See [devfile registry contributing guide](https://github.com/devfile/registry/blob/main/CONTRIBUTING.md) on how to test changes)_


### How to test changes / Special notes to the reviewer: