### PR TITLE
Telemetry fix for community registry viewer deployment

### DIFF
--- a/.ci/deploy/devfile-registry.yaml
+++ b/.ci/deploy/devfile-registry.yaml
@@ -126,7 +126,7 @@ objects:
               cpu: 250m
               memory: ${REGISTRY_VIEWER_MEMORY_LIMIT}
           env:
-            - name: ANALYTICS_WRITE_KEY 
+            - name: NEXT_PUBLIC_ANALYTICS_WRITE_KEY 
               value: ${ANALYTICS_WRITE_KEY}
             - name: DEVFILE_REGISTRIES 
               value: |- 
@@ -224,7 +224,7 @@ objects:
             path: /metrics
 
     .env.registry-viewer: |
-      ANALYTICS_WRITE_KEY=${ANALYTICS_WRITE_KEY}
+      NEXT_PUBLIC_ANALYTICS_WRITE_KEY=${ANALYTICS_WRITE_KEY}
       DEVFILE_REGISTRIES=[{"name":"Community","url":"http://localhost:8080","fqdn":"${REGISTRY_HOST_ALIAS}"}]
 
 - apiVersion: v1


### PR DESCRIPTION
### What does this PR do?:
_Summarize the changes. Are any stacks or samples added or updated?_

Corrects the environment variable name for the analytics write key, `ANALYTICS_WRITE_KEY` to `NEXT_PUBLIC_ANALYTICS_WRITE_KEY`. This change should fix the broken telemetry.

### Which issue(s) this PR fixes:
_Link to github issue(s)_

fixes devfile/api#1006

### PR acceptance criteria:

- [ ] Contributing guide
_Have you read the [devfile registry contributing guide](https://github.com/devfile/registry/blob/main/CONTRIBUTING.md) and followed its instructions?_
- [ ] Test automation
_Does this repository's tests pass with your changes?_
- [ ] Documentation
_Does any documentation need to be updated with your changes?_
- [ ] Check Tools Provider
_Have you tested the changes with existing tools, i.e. Odo, Che, Console? (See [devfile registry contributing guide](https://github.com/devfile/registry/blob/main/CONTRIBUTING.md) on how to test changes)_


### How to test changes / Special notes to the reviewer: