### PR TITLE
Blank registry viewer analytics write key in OpenShift template

### DIFF
--- a/.ci/deploy/devfile-registry.yaml
+++ b/.ci/deploy/devfile-registry.yaml
@@ -291,7 +291,7 @@ parameters:
   displayName: Devfile registry hostname alias
   description: The hostname alias to pass in to the devfile registry viewer's config.
 - name: ANALYTICS_WRITE_KEY
-  value: S2rfQJo8xA9nyLhdY2CnTrWqlUgHqmwq
+  value: ""
   displayName: Public write key for segment.io
   description: The public write key to send viewer analytics to segment.io
 - name: TELEMETRY_KEY


### PR DESCRIPTION
### What does this PR do?:
_Summarize the changes. Are any stacks or samples added or updated?_

Blanks the analytics write key from the default value of the parameter in the OpenShift template. Since the analytics write key is now set on production deployment, there is no need to have the key set by default in the OpenShift template.

### Which issue(s) this PR fixes:
_Link to github issue(s)_

### PR acceptance criteria:

- [ ] Contributing guide
_Have you read the [devfile registry contributing guide](https://github.com/devfile/registry/blob/main/CONTRIBUTING.md) and followed its instructions?_
- [ ] Test automation
_Does this repository's tests pass with your changes?_
- [ ] Documentation
_Does any documentation need to be updated with your changes?_
- [ ] Check Tools Provider
_Have you tested the changes with existing tools, i.e. Odo, Che, Console? (See [devfile registry contributing guide](https://github.com/devfile/registry/blob/main/CONTRIBUTING.md) on how to test changes)_


### How to test changes / Special notes to the reviewer: