### PR TITLE
Add liveness and readiness probes to registry viewer container in the OpenShift template

### DIFF
--- a/.ci/deploy/devfile-registry.yaml
+++ b/.ci/deploy/devfile-registry.yaml
@@ -109,8 +109,6 @@ objects:
         - image: ${REGISTRY_VIEWER_IMAGE}:${IMAGE_TAG}
           imagePullPolicy: "${REGISTRY_VIEWER_PULL_POLICY}"
           name: devfile-registry-viewer
-          ports:
-          - containerPort: 3000
           securityContext:
             allowPrivilegeEscalation: false
             runAsNonRoot: true

--- a/.ci/deploy/devfile-registry.yaml
+++ b/.ci/deploy/devfile-registry.yaml
@@ -91,7 +91,7 @@ objects:
               scheme: HTTP
             initialDelaySeconds: 30
             periodSeconds: 10
-            timeoutSeconds: 10
+            timeoutSeconds: 20
           resources:
             requests:
               cpu: 100m
@@ -123,7 +123,7 @@ objects:
               scheme: HTTP
             initialDelaySeconds: 15
             periodSeconds: 10
-            timeoutSeconds: 3
+            timeoutSeconds: 20
           readinessProbe:
             httpGet:
               path: /viewer
@@ -131,7 +131,7 @@ objects:
               scheme: HTTP
             initialDelaySeconds: 15
             periodSeconds: 10
-            timeoutSeconds: 3
+            timeoutSeconds: 20
           resources:
             requests:
               cpu: 100m

--- a/.ci/deploy/devfile-registry.yaml
+++ b/.ci/deploy/devfile-registry.yaml
@@ -118,6 +118,22 @@ objects:
               drop: ["ALL"]
             seccompProfile:
               type: "RuntimeDefault"
+          livenessProbe:
+            httpGet:
+              path: /viewer
+              port: 3000
+              scheme: HTTP
+            initialDelaySeconds: 15
+            periodSeconds: 10
+            timeoutSeconds: 3
+          readinessProbe:
+            httpGet:
+              path: /viewer
+              port: 3000
+              scheme: HTTP
+            initialDelaySeconds: 15
+            periodSeconds: 10
+            timeoutSeconds: 3
           resources:
             requests:
               cpu: 100m


### PR DESCRIPTION
### What does this PR do?:
_Summarize the changes. Are any stacks or samples added or updated?_

Adds missing required probes removed in devfile/api#1019.

Additional changes:

- Removes unnecessary port forward to registry viewer container

### Which issue(s) this PR fixes:
_Link to github issue(s)_

part of devfile/api#1040

### PR acceptance criteria:

- [ ] Contributing guide
_Have you read the [devfile registry contributing guide](https://github.com/devfile/registry/blob/main/CONTRIBUTING.md) and followed its instructions?_
- [ ] Test automation
_Does this repository's tests pass with your changes?_
- [ ] Documentation
_Does any documentation need to be updated with your changes?_
- [ ] Check Tools Provider
_Have you tested the changes with existing tools, i.e. Odo, Che, Console? (See [devfile registry contributing guide](https://github.com/devfile/registry/blob/main/CONTRIBUTING.md) on how to test changes)_


### How to test changes / Special notes to the reviewer: