### PR TITLE
[java-quarkus] Use LTS JDK 17 image

### DIFF
--- a/stacks/java-quarkus/devfile.yaml
+++ b/stacks/java-quarkus/devfile.yaml
@@ -1,7 +1,7 @@
 schemaVersion: 2.1.0
 metadata:
   name: java-quarkus
-  version: 1.3.0
+  version: 1.4.0
   website: https://quarkus.io
   displayName: Quarkus Java
   description: Quarkus with Java
@@ -21,7 +21,7 @@ starterProjects:
 components:
   - name: tools
     container:
-      image: registry.access.redhat.com/ubi8/openjdk-17
+      image: registry.access.redhat.com/ubi9/openjdk-17:latest
       args: ['tail', '-f', '/dev/null']
       memoryLimit: 512Mi ## default app nowhere needs this but leaving room for expansion.
       mountSources: true


### PR DESCRIPTION
### What does this PR do?:
This updates the container image to `registry.access.redhat.com/ubi9/openjdk-17`, to keep up with the latest JDK LTS, security-wise.

### Which issue(s) this PR fixes:
&mdash;

### PR acceptance criteria:

- [x] Contributing guide
_Have you read the [devfile registry contributing guide](https://github.com/devfile/registry/blob/main/CONTRIBUTING.md) and followed its instructions?_
- [ ] Test automation
_Does this repository's tests pass with your changes?_
- [ ] Documentation
_Does any documentation need to be updated with your changes?_
- [x] Check Tools Provider
_Have you tested the changes with existing tools, i.e. Odo, Che, Console? (See [devfile registry contributing guide](https://github.com/devfile/registry/blob/main/CONTRIBUTING.md) on how to test changes)_
Tested with `odo`.

### How to test changes / Special notes to the reviewer: