### PR TITLE
[java-springboot] Use LTS JDK 17 image

### DIFF
--- a/stacks/java-springboot/1.3.0/devfile.yaml
+++ b/stacks/java-springboot/1.3.0/devfile.yaml
@@ -1,0 +1,65 @@
+schemaVersion: 2.1.0
+metadata:
+  name: java-springboot
+  displayName: Spring Boot®
+  description: Java application using Spring Boot® and OpenJDK 11
+  icon: https://raw.githubusercontent.com/devfile-samples/devfile-stack-icons/main/spring.svg
+  tags:
+    - Java
+    - Spring
+  projectType: springboot
+  language: Java
+  version: 1.3.0
+  globalMemoryLimit: 2674Mi
+starterProjects:
+  - name: springbootproject
+    git:
+      remotes:
+        origin: "https://github.com/odo-devfiles/springboot-ex.git"
+components:
+  - name: tools
+    container:
+      image: registry.access.redhat.com/ubi9/openjdk-17:1.16-1.1696518670
+      command: ["tail", "-f", "/dev/null"]
+      memoryLimit: 768Mi
+      mountSources: true
+      endpoints:
+        - name: http-springboot
+          targetPort: 8080
+        - exposure: none
+          name: debug
+          targetPort: 5858
+      volumeMounts:
+        - name: m2
+          path: /home/user/.m2
+      env:
+        - name: DEBUG_PORT
+          value: "5858"
+  - name: m2
+    volume:
+      size: 3Gi
+commands:
+  - id: build
+    exec:
+      component: tools
+      workingDir: ${PROJECT_SOURCE}
+      commandLine: "mvn clean -Dmaven.repo.local=/home/user/.m2/repository package -Dmaven.test.skip=true"
+      group:
+        kind: build
+        isDefault: true
+  - id: run
+    exec:
+      component: tools
+      workingDir: ${PROJECT_SOURCE}
+      commandLine: "mvn -Dmaven.repo.local=/home/user/.m2/repository spring-boot:run"
+      group:
+        kind: run
+        isDefault: true
+  - id: debug
+    exec:
+      component: tools
+      workingDir: ${PROJECT_SOURCE}
+      commandLine: "java -Xdebug -Xrunjdwp:server=y,transport=dt_socket,address=${DEBUG_PORT},suspend=n -jar target/*.jar"
+      group:
+        kind: debug
+        isDefault: true

--- a/stacks/java-springboot/2.1.0/devfile.yaml
+++ b/stacks/java-springboot/2.1.0/devfile.yaml
@@ -1,0 +1,92 @@
+schemaVersion: 2.2.0
+metadata:
+  name: java-springboot
+  displayName: Spring Boot®
+  description: Java application using Spring Boot® and OpenJDK 11
+  icon: https://raw.githubusercontent.com/devfile-samples/devfile-stack-icons/main/spring.svg
+  tags:
+    - Java
+    - Spring
+  projectType: springboot
+  language: Java
+  version: 2.1.0
+  globalMemoryLimit: 2674Mi
+starterProjects:
+  - name: springbootproject
+    git:
+      remotes:
+        origin: "https://github.com/odo-devfiles/springboot-ex.git"
+components:
+  - name: tools
+    container:
+      image: registry.access.redhat.com/ubi9/openjdk-17:1.16-1.1696518670
+      command: ['tail', '-f', '/dev/null']
+      memoryLimit: 768Mi
+      mountSources: true
+      endpoints:
+        - name: http-springboot
+          targetPort: 8080
+        - exposure: none
+          name: debug
+          targetPort: 5858
+      volumeMounts:
+        - name: m2
+          path: /home/user/.m2
+      env:
+        - name: DEBUG_PORT
+          value: "5858"
+  - name: m2
+    volume:
+      size: 3Gi
+  - name: build
+    image:
+      imageName: java-springboot-image:latest
+      dockerfile:
+        uri: docker/Dockerfile
+        buildContext: .
+        rootRequired: false
+  - name: deploy
+    kubernetes:
+      uri: kubernetes/deploy.yaml
+      endpoints:
+        - name: http-8081
+          targetPort: 8081
+commands:
+  - id: build
+    exec:
+      component: tools
+      workingDir: ${PROJECT_SOURCE}
+      commandLine: 'mvn clean -Dmaven.repo.local=/home/user/.m2/repository package -Dmaven.test.skip=true'
+      group:
+        kind: build
+        isDefault: true
+  - id: run
+    exec:
+      component: tools
+      workingDir: ${PROJECT_SOURCE}
+      commandLine: 'mvn -Dmaven.repo.local=/home/user/.m2/repository spring-boot:run'
+      group:
+        kind: run
+        isDefault: true
+  - id: debug
+    exec:
+      component: tools
+      workingDir: ${PROJECT_SOURCE}
+      commandLine: 'java -Xdebug -Xrunjdwp:server=y,transport=dt_socket,address=${DEBUG_PORT},suspend=n -jar target/*.jar'
+      group:
+        kind: debug
+        isDefault: true
+  - id: build-image
+    apply:
+      component: build
+  - id: deployk8s
+    apply:
+      component: deploy
+  - id: deploy
+    composite:
+      commands:
+        - build-image
+        - deployk8s
+      group:
+        kind: deploy
+        isDefault: true

--- a/stacks/java-springboot/2.1.0/docker/Dockerfile
+++ b/stacks/java-springboot/2.1.0/docker/Dockerfile
@@ -1,0 +1,27 @@
+####
+# This Dockerfile is used in order to build a container that runs the Spring Boot application
+#
+# Build the image with:
+#
+# docker build -f docker/Dockerfile -t springboot/sample-demo .
+#
+# Then run the container using:
+#
+# docker run -i --rm -p 8081:8081 springboot/sample-demo
+####
+FROM quay.io/devfile/maven:3.8.1-openjdk-17-slim
+
+WORKDIR /build
+
+# Build dependency offline to streamline build
+COPY pom.xml .
+RUN mvn dependency:go-offline
+
+COPY src src
+RUN mvn package -Dmaven.test.skip=true
+
+FROM registry.access.redhat.com/ubi9/openjdk-17-runtime:latest
+COPY --from=0 /build/target/demo-0.0.1-SNAPSHOT.jar /app/target/demo-0.0.1-SNAPSHOT.jar
+
+EXPOSE 8081
+ENTRYPOINT [ "java", "-jar", "/app/target/demo-0.0.1-SNAPSHOT.jar", "--server.port=8081" ]

--- a/stacks/java-springboot/2.1.0/kubernetes/deploy.yaml
+++ b/stacks/java-springboot/2.1.0/kubernetes/deploy.yaml
@@ -1,0 +1,41 @@
+kind: Service
+apiVersion: v1
+metadata:
+  name: my-java-springboot-svc
+spec:
+  ports:
+    - name: http-8081
+      port: 8081
+      protocol: TCP
+      targetPort: 8081
+  selector:
+    app: java-springboot-app
+---
+kind: Deployment
+apiVersion: apps/v1
+metadata:
+  name: my-java-springboot
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: java-springboot-app
+  template:
+    metadata:
+      labels:
+        app: java-springboot-app
+    spec:
+      containers:
+        - name: my-java-springboot
+          image: java-springboot-image:latest
+          ports:
+            - name: http
+              containerPort: 8081
+              protocol: TCP
+          resources:
+            requests:
+              memory: "180Mi"
+              cpu: "10m"
+            limits:
+              memory: "300Mi"
+              cpu: "100m"

--- a/stacks/java-springboot/stack.yaml
+++ b/stacks/java-springboot/stack.yaml
@@ -8,3 +8,5 @@ versions:
   # 1.3.0: with JDK 17
   - version: 1.3.0
   - version: 2.0.0
+  # 2.1.0: with JDK 17
+  - version: 2.1.0

--- a/stacks/java-springboot/stack.yaml
+++ b/stacks/java-springboot/stack.yaml
@@ -5,4 +5,6 @@ icon: https://raw.githubusercontent.com/devfile-samples/devfile-stack-icons/main
 versions:
   - version: 1.2.0
     default: true # should have one and only one default version
+  # 1.3.0: with JDK 17
+  - version: 1.3.0
   - version: 2.0.0

--- a/stacks/java-springboot/stack.yaml
+++ b/stacks/java-springboot/stack.yaml
@@ -4,9 +4,9 @@ displayName: Spring Boot
 icon: https://raw.githubusercontent.com/devfile-samples/devfile-stack-icons/main/spring.svg
 versions:
   - version: 1.2.0
-    default: true # should have one and only one default version
   # 1.3.0: with JDK 17
   - version: 1.3.0
+    default: true # should have one and only one default version
   - version: 2.0.0
   # 2.1.0: with JDK 17
   - version: 2.1.0


### PR DESCRIPTION
### What does this PR do?:
This updates the container image to `registry.access.redhat.com/ubi9/openjdk-17`, to keep up with the latest JDK LTS, security-wise.
Also JDK 17 is now a requirement for recent versions of Spring Boot.

### Which issue(s) this PR fixes:
&mdash;

### PR acceptance criteria:

- [x] Contributing guide
_Have you read the [devfile registry contributing guide](https://github.com/devfile/registry/blob/main/CONTRIBUTING.md) and followed its instructions?_
- [x] Test automation
_Does this repository's tests pass with your changes?_
- [ ] Documentation
_Does any documentation need to be updated with your changes?_
- [x] Check Tools Provider
_Have you tested the changes with existing tools, i.e. Odo, Che, Console? (See [devfile registry contributing guide](https://github.com/devfile/registry/blob/main/CONTRIBUTING.md) on how to test changes)_
Tested with `odo`.

### How to test changes / Special notes to the reviewer: