### PR TITLE
ci: updating go version to 1.18

### DIFF
--- a/.ci/Dockerfile
+++ b/.ci/Dockerfile
@@ -12,7 +12,7 @@
 #   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 #   See the License for the specific language governing permissions and
 #   limitations under the License.
-FROM quay.io/openshift-pipeline/golang:1.15-alpine AS builder
+FROM golang:1.18-alpine AS builder
 
 # Install dependencies
 

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -36,7 +36,7 @@ jobs:
       - name: Setup Go environment
         uses: actions/setup-go@v2
         with:
-          go-version: 1.13
+          go-version: 1.18
 
       - name: Check if devfile registry build is working
         run: registry-repo/.ci/build.sh


### PR DESCRIPTION
### What does this PR do?:
_Summarize the changes. Are any stacks or samples added or updated?_
Updates go version to 1.18 for ci due to changes from https://github.com/devfile/registry-support/pull/169

### Which issue(s) this PR fixes:
_Link to github issue(s)_

### PR acceptance criteria:

- [x] Contributing guide
_Have you read the [devfile registry contributing guide](https://github.com/devfile/registry/blob/main/CONTRIBUTING.md) and followed its instructions?_
- [ ] Test automation
_Does this repository's tests pass with your changes?_
- [ ] Documentation
_Does any documentation need to be updated with your changes?_
- [x] Check Tools Provider
_Have you tested the changes with existing tools, i.e. Odo, Che, Console? (See [devfile registry contributing guide](https://github.com/devfile/registry/blob/main/CONTRIBUTING.md) on how to test changes)_


### How to test changes / Special notes to the reviewer: