### PR TITLE
Update builder image tag for CI

### DIFF
--- a/.ci/Dockerfile
+++ b/.ci/Dockerfile
@@ -14,7 +14,7 @@
 #   limitations under the License.
 FROM registry.access.redhat.com/ubi8/go-toolset:1.18 AS builder
 
-# Run as root
+# Set user as root
 USER root
 
 # Install yq
@@ -27,6 +27,9 @@ RUN git clone https://github.com/devfile/registry-support.git /registry-support
 
 # Run the registry build tools
 RUN /registry-support/build-tools/build.sh /registry /build
+
+# Set user as non-root
+USER 1001
 
 FROM quay.io/devfile/devfile-index-base:next
 

--- a/.ci/Dockerfile
+++ b/.ci/Dockerfile
@@ -12,7 +12,7 @@
 #   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 #   See the License for the specific language governing permissions and
 #   limitations under the License.
-FROM golang:1.18-alpine AS builder
+FROM registry.access.redhat.com/ubi8/go-toolset:1.18 AS builder
 
 # Install dependencies
 

--- a/.ci/Dockerfile
+++ b/.ci/Dockerfile
@@ -1,5 +1,5 @@
 #
-#   Copyright 2020-2022 Red Hat, Inc.
+#   Copyright 2020-2023 Red Hat, Inc.
 #
 #   Licensed under the Apache License, Version 2.0 (the "License");
 #   you may not use this file except in compliance with the License.

--- a/.ci/Dockerfile
+++ b/.ci/Dockerfile
@@ -14,9 +14,8 @@
 #   limitations under the License.
 FROM registry.access.redhat.com/ubi8/go-toolset:1.18 AS builder
 
-# Install dependencies
-
-RUN apk add --no-cache git bash curl zip
+# Run as root
+USER root
 
 # Install yq
 RUN curl -sL -O https://github.com/mikefarah/yq/releases/download/v4.9.5/yq_linux_amd64 -o /usr/local/bin/yq && mv ./yq_linux_amd64 /usr/local/bin/yq && chmod +x /usr/local/bin/yq


### PR DESCRIPTION
### What does this PR do?:
_Summarize the changes. Are any stacks or samples added or updated?_

Updates image tag of the builder step under the [`Dockerfile`](https://github.com/devfile/registry/blob/5cda5e5156073a512373c4a738424cc349446b26/.ci/Dockerfile#L15) to use `registry.access.redhat.com/ubi8/go-toolset` due to the deployment environment's restriction, denying image pulls from Docker Hub.

### Which issue(s) this PR fixes:
_Link to github issue(s)_

fixes devfile/api#1083

### PR acceptance criteria:

- [ ] Contributing guide
_Have you read the [devfile registry contributing guide](https://github.com/devfile/registry/blob/main/CONTRIBUTING.md) and followed its instructions?_
- [ ] Test automation
_Does this repository's tests pass with your changes?_
- [ ] Documentation
_Does any documentation need to be updated with your changes?_
- [ ] Check Tools Provider
_Have you tested the changes with existing tools, i.e. Odo, Che, Console? (See [devfile registry contributing guide](https://github.com/devfile/registry/blob/main/CONTRIBUTING.md) on how to test changes)_


### How to test changes / Special notes to the reviewer: