### PR TITLE
Add probe timeout variable to acceptance testing template

### DIFF
--- a/.ci/acceptance-tests/devfile-registry-acceptance.yaml
+++ b/.ci/acceptance-tests/devfile-registry-acceptance.yaml
@@ -21,6 +21,8 @@ objects:
             env:
               - name: REGISTRY
                 value: ${REGISTRY}
+              - name: PROBE_TIMEOUT
+                value: ${PROBE_TIMEOUT}
             resources:
               requests:
                 cpu: 20m
@@ -41,6 +43,11 @@ parameters:
 - name: REGISTRY
   value: "https://registry.stage.devfile.io"
   required: true
+- name: PROBE_TIMEOUT
+  value: "600"
+  description: |- 
+    The maximum time in seconds the test suite will wait 
+    for the target deployment to be in ready state.
 - name: JOB_NAME
   generate: expression
   from: "[a-z0-9]{5}"


### PR DESCRIPTION
### What does this PR do?:
_Summarize the changes. Are any stacks or samples added or updated?_

Adds environment variable required to the acceptance testing OpenShift template which enables the delay on testing to probe the target registry for readiness, a feature added in devfile/api#1086.

This ensures acceptance testing is perform *after* the staging deployment is ready.

### Which issue(s) this PR fixes:
_Link to github issue(s)_

fixes devfile/api#1095

### PR acceptance criteria:

- [ ] Contributing guide
_Have you read the [devfile registry contributing guide](https://github.com/devfile/registry/blob/main/CONTRIBUTING.md) and followed its instructions?_
- [ ] Test automation
_Does this repository's tests pass with your changes?_
- [ ] Documentation
_Does any documentation need to be updated with your changes?_
- [ ] Check Tools Provider
_Have you tested the changes with existing tools, i.e. Odo, Che, Console? (See [devfile registry contributing guide](https://github.com/devfile/registry/blob/main/CONTRIBUTING.md) on how to test changes)_


### How to test changes / Special notes to the reviewer: