### PR TITLE
fix(ci): using name only flag for getting changed pr files

### DIFF
--- a/tests/get_stacks.sh
+++ b/tests/get_stacks.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-diff=$(git diff origin/main HEAD --stat)
+diff=$(git diff origin/main HEAD --name-only)
 
 changed_stacks=()
 


### PR DESCRIPTION
### What does this PR do?:
_Summarize the changes. Are any stacks or samples added or updated?_

Changes the git diff output that is used to get stacks changed for pr delta testing from this:

```
stacks/go/{1.0.2 => 1.1.0}/devfile.yaml               | 25 ++++++++++++++++++++++++-
stacks/go/{2.0.0 => 2.1.0}/devfile.yaml               | 25 ++++++++++++++++++++++++-
stacks/go/{2.0.0 => 2.1.0}/docker/Dockerfile          |  0
stacks/go/{2.0.0 => 2.1.0}/kubernetes/deploy.yaml     |  0
stacks/go/stack.yaml                                  |  4 ++--
tests/get_stacks.sh                                   |  2 +-
7 files changed, 51 insertions(+), 12 deletions(-)
```

to this:

```
stacks/go/1.1.0/devfile.yaml
stacks/go/2.1.0/devfile.yaml
stacks/go/2.1.0/docker/Dockerfile
stacks/go/2.1.0/kubernetes/deploy.yaml
stacks/go/stack.yaml
tests/get_stacks.sh
```

which then allows the regex `stacks\/(.*)\/devfile\.yaml` to match correctly

### Which issue(s) this PR fixes:
https://github.com/devfile/api/issues/1097

### PR acceptance criteria:

- [x] Contributing guide
_Have you read the [devfile registry contributing guide](https://github.com/devfile/registry/blob/main/CONTRIBUTING.md) and followed its instructions?_
- [x] Test automation
_Does this repository's tests pass with your changes?_
- [x] Documentation
_Does any documentation need to be updated with your changes?_
- [ ] Check Tools Provider
_Have you tested the changes with existing tools, i.e. Odo, Che, Console? (See [devfile registry contributing guide](https://github.com/devfile/registry/blob/main/CONTRIBUTING.md) on how to test changes)_


### How to test changes / Special notes to the reviewer: