### PR TITLE
Adding a devfile for the Universal Developer Image

### DIFF
--- a/stacks/udi/OWNERS
+++ b/stacks/udi/OWNERS
@@ -1,0 +1,5 @@
+# See the OWNERS docs: https://go.k8s.io/owners
+
+reviewers:
+- ibuziuk
+- l0rd

--- a/stacks/udi/devfile.yaml
+++ b/stacks/udi/devfile.yaml
@@ -1,0 +1,29 @@
+schemaVersion: 2.2.0
+metadata:
+  name: udi
+  displayName: Universal Developer Image
+  description: Universal Developer Image provides various programming languages tools and runtimes for instant coding
+  icon: https://landscape.cncf.io/logos/devfile.svg
+  tags:
+    - Java
+    - Maven
+    - Scala
+    - PHP
+    - .NET
+    - Node.js
+    - Go
+    - Python
+    - Pip
+    - ubi8
+  projectType: universal
+  language: Polyglot
+  version: 1.0.0
+components:
+  - name: tools
+    container:
+      image: quay.io/devfile/universal-developer-image:ubi8-latest
+      memoryLimit: 6G
+      memoryRequest: 512Mi
+      cpuRequest: 1000m
+      cpuLimit: 4000m
+      mountSources: true


### PR DESCRIPTION
### What does this PR do?:
Adding a devfile for the Universal Developer Image

### Which issue(s) this PR fixes:
https://github.com/eclipse/che/issues/22126

### PR acceptance criteria:

- [ ] Contributing guide
_Have you read the [devfile registry contributing guide](https://github.com/devfile/registry/blob/main/CONTRIBUTING.md) and followed its instructions?_
- [ ] Test automation
_Does this repository's tests pass with your changes?_
- [ ] Documentation
_Does any documentation need to be updated with your changes?_
- [ ] Check Tools Provider
_Have you tested the changes with existing tools, i.e. Odo, Che, Console? (See [devfile registry contributing guide](https://github.com/devfile/registry/blob/main/CONTRIBUTING.md) on how to test changes)_


### How to test changes / Special notes to the reviewer:
- build is failing due to the fact that `metadata.projectType` is not set. Not sure why the field is required though, according to the spec it is optional
- tested against workspaces.openshift.com via https://raw.githubusercontent.com/ibuziuk/registry/udi_devfile/stacks/udi/devfile.yaml (empty workspace is created, 'tools' is provisioned)

![image](https://user-images.githubusercontent.com/1461122/230425796-ab4ad065-bfe9-45b6-8f60-84d19ba5fa4a.png)

- need to add an icon for the stack, can we potentially reuse devfile icon?