### PR TITLE
WIP: Add PRs older than a week to the PRs project

### DIFF
--- a/.github/workflows/add-labels-to-prs.yaml
+++ b/.github/workflows/add-labels-to-prs.yaml
@@ -1,0 +1,17 @@
+name: Add 'needs-review' label to PRs
+on:
+  schedule:
+  - cron:  '0 0 * * *'
+jobs:
+  add-labels-to-old-prs:
+    runs-on: ubuntu-latest
+    steps:
+    - name: Add need-review label to pull requests
+      uses: crazymanish/pullrequest-attention-label-action@v1.0.1
+
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        ADD_LABEL: "needs-review"
+        AFTER_DAYS: 7
+        SKIP_LABELS: "approved,wip,do-not-merge/work-in-progress"
+        REMOVE_LABELS: "helpwanted,untriaged"

--- a/.github/workflows/add-prs-to-reviews-project.yaml
+++ b/.github/workflows/add-prs-to-reviews-project.yaml
@@ -1,0 +1,15 @@
+name: Add labeled PRs to Project
+on:
+  pull_request:
+    types:
+      - labeled
+jobs:
+  add-pr-to-project:
+    name: Add pull request to project
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/add-to-project@v0.5.0
+        with:
+          project-url: ${{ secrets.PR_REVIEW_NEEDED_PROJECT_URL }}
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          labeled: needs-review


### PR DESCRIPTION
### What does this PR do?:

**PR is WIP because we have to add secrets to the current REPO (project URL)**

Creates two different workflows:
* `add-labels-to-prs`: Is a scheduled job with `cron: "0 0 * * *"` that checks all opened PRs if they are older than a week. If yes, and they don't have `approved`, `wip` , `do-not-merge/work-in-progress` labels it adds the `needs-review` label to them.
* `add-pr-to-reviews-project`: Is an event triggered job (`pr-labeled`) and adds a PR with label `needs-revie` to the [Needs-Review Project](https://github.com/orgs/devfile/projects/8).

The schema for this workflow is:

![image](https://user-images.githubusercontent.com/12788684/230895749-93b33f4c-e982-4472-9203-e5804d8a88a0.png)

### Which issue(s) this PR fixes:
_Link to github issue(s)_

### PR acceptance criteria:

- [x] Contributing guide
_Have you read the [devfile registry contributing guide](https://github.com/devfile/registry/blob/main/CONTRIBUTING.md) and followed its instructions?_
- [x] Test automation
_Does this repository's tests pass with your changes?_
- [x] Documentation
_Does any documentation need to be updated with your changes?_
- [x] Check Tools Provider
_Have you tested the changes with existing tools, i.e. Odo, Che, Console? (See [devfile registry contributing guide](https://github.com/devfile/registry/blob/main/CONTRIBUTING.md) on how to test changes)_


### How to test changes / Special notes to the reviewer:
An identical workflow is [here](https://github.com/thepetk/gpg_card_reset/actions)