### PR TITLE
Update dotnet tags to improve alizer devfile matching

### DIFF
--- a/stacks/dotnet50/devfile.yaml
+++ b/stacks/dotnet50/devfile.yaml
@@ -6,6 +6,7 @@ metadata:
   icon: https://github.com/dotnet/brand/raw/main/logo/dotnet-logo.png
   tags:
     - .NET
+    - .NET 5.0
   projectType: dotnet
   language: .NET
   version: 1.0.3

--- a/stacks/dotnet60/devfile.yaml
+++ b/stacks/dotnet60/devfile.yaml
@@ -6,6 +6,7 @@ metadata:
   icon: https://github.com/dotnet/brand/raw/main/logo/dotnet-logo.png
   tags:
     - .NET
+    - .NET 6.0
   projectType: dotnet
   language: .NET
   version: 1.0.2

--- a/stacks/dotnetcore31/devfile.yaml
+++ b/stacks/dotnetcore31/devfile.yaml
@@ -6,6 +6,7 @@ metadata:
   icon: https://github.com/dotnet/brand/raw/main/logo/dotnet-logo.png
   tags:
     - .NET
+    - .NET Core App 3.1
   projectType: dotnet
   language: .NET
   version: 1.0.3


### PR DESCRIPTION
### What does this PR do?:
This PR is related to [alizer#135](https://github.com/redhat-developer/alizer/issues/135).

The 3 devfiles related to `.NET` have the same set of tags, and they are not explicitly mention their `.NET` framework. In case we add specific tags (e.g `.NET 5.0`), `alizer` should be able to pick the correct devfile. Right now, it finds 3 devfiles having the same list of tags and as a result it calculates the same weight for each one of them.

### Which issue(s) this PR fixes:
fixes https://github.com/devfile/api/issues/1087

### PR acceptance criteria:

- [x] Contributing guide
_Have you read the [devfile registry contributing guide](https://github.com/devfile/registry/blob/main/CONTRIBUTING.md) and followed its instructions?_
- [x] Test automation
_Does this repository's tests pass with your changes?_
- [x] Documentation
_Does any documentation need to be updated with your changes?_
- [x] Check Tools Provider
_Have you tested the changes with existing tools, i.e. Odo, Che, Console? (See [devfile registry contributing guide](https://github.com/devfile/registry/blob/main/CONTRIBUTING.md) on how to test changes)_


### How to test changes / Special notes to the reviewer: