### PR TITLE
[Devtools Week] Update python image tags

### DIFF
--- a/stacks/python-django/devfile.yaml
+++ b/stacks/python-django/devfile.yaml
@@ -22,7 +22,7 @@ starterProjects:
 components:
   - name: py-web
     container:
-      image: registry.access.redhat.com/ubi9/python-39:1-122
+      image: registry.access.redhat.com/ubi9/python-39:1-117.1684741281
       args: ["tail", "-f", "/dev/null"]
       mountSources: true
       endpoints:

--- a/stacks/python-django/devfile.yaml
+++ b/stacks/python-django/devfile.yaml
@@ -22,7 +22,7 @@ starterProjects:
 components:
   - name: py-web
     container:
-      image: registry.access.redhat.com/ubi9/python-39:1-108
+      image: registry.access.redhat.com/ubi9/python-39:1-122
       args: ["tail", "-f", "/dev/null"]
       mountSources: true
       endpoints:

--- a/stacks/python/2.1.0/devfile.yaml
+++ b/stacks/python/2.1.0/devfile.yaml
@@ -24,7 +24,7 @@ starterProjects:
 components:
   - name: py
     container:
-      image: registry.access.redhat.com/ubi9/python-39:1-122
+      image: registry.access.redhat.com/ubi9/python-39:1-117.1684741281
       args: ['tail', '-f', '/dev/null']
       mountSources: true
       endpoints:

--- a/stacks/python/2.1.0/devfile.yaml
+++ b/stacks/python/2.1.0/devfile.yaml
@@ -24,7 +24,7 @@ starterProjects:
 components:
   - name: py
     container:
-      image: registry.access.redhat.com/ubi9/python-39:1-108
+      image: registry.access.redhat.com/ubi9/python-39:1-122
       args: ['tail', '-f', '/dev/null']
       mountSources: true
       endpoints:

--- a/stacks/python/3.0.0/devfile.yaml
+++ b/stacks/python/3.0.0/devfile.yaml
@@ -24,7 +24,7 @@ starterProjects:
 components:
   - name: py
     container:
-      image: registry.access.redhat.com/ubi9/python-39:1-122
+      image: registry.access.redhat.com/ubi9/python-39:1-117.1684741281
       args: ['tail', '-f', '/dev/null']
       mountSources: true
       endpoints:

--- a/stacks/python/3.0.0/devfile.yaml
+++ b/stacks/python/3.0.0/devfile.yaml
@@ -24,7 +24,7 @@ starterProjects:
 components:
   - name: py
     container:
-      image: registry.access.redhat.com/ubi9/python-39:1-108
+      image: registry.access.redhat.com/ubi9/python-39:1-122
       args: ['tail', '-f', '/dev/null']
       mountSources: true
       endpoints:


### PR DESCRIPTION
### What does this PR do?:
_Summarize the changes. Are any stacks or samples added or updated?_
This task is part of the devtools week. Updates the python image `registry.access.redhat.com/ubi9/python-39` from tag `1-108` to `1-122`.

### Which issue(s) this PR fixes:
_Link to github issue(s)_


### PR acceptance criteria:

- [x] Contributing guide
_Have you read the [devfile registry contributing guide](https://github.com/devfile/registry/blob/main/CONTRIBUTING.md) and followed its instructions?_
- [x] Test automation
_Does this repository's tests pass with your changes?_
- [x] Documentation
_Does any documentation need to be updated with your changes?_
- [x] Check Tools Provider
_Have you tested the changes with existing tools, i.e. Odo, Che, Console? (See [devfile registry contributing guide](https://github.com/devfile/registry/blob/main/CONTRIBUTING.md) on how to test changes)_


### How to test changes / Special notes to the reviewer: