### PR TITLE
cleanup minikube docker image in non terminating test

### DIFF
--- a/tests/check_non_terminating.sh
+++ b/tests/check_non_terminating.sh
@@ -107,6 +107,13 @@ isNonTerminating() {
   if kubectl wait pods -n "${TEST_NAMESPACE}" test-terminating --for condition=Ready --timeout=${timeout_in_sec}s >/dev/null 2>&1; then
     echo "  SUCCESS: The container started successfully and didn't terminate"
     kubectl delete pod test-terminating -n "${TEST_NAMESPACE}" >/dev/null 2>&1
+
+    # remove image to save space
+    if [ "$ENV" = "minikube" ]; then
+      echo "  COMMAND: \"minikube ssh docker image rm $_int_image\""
+      minikube ssh docker image rm $_int_image >/dev/null 2>&1
+    fi
+
     return 0
   else
     echo "  ERROR: Failed to reach \"Ready\" condition after $timeout_in_sec seconds"


### PR DESCRIPTION
### What does this PR do?:
Removes the docker image being tested in the `check_non_terminating.sh` script after the container has been checked for termination.

This is needed because in the case where the list of images being tested is large (nightly runs or merging to main), the images are all downloaded to the Github runner and consumes all the disk space.

Removing the image after is has been marked as successful allows all the images to be tested in the same Github workflow run.

### Which issue(s) this PR fixes:
fixes https://github.com/devfile/api/issues/1135

### PR acceptance criteria:

- [x] Contributing guide
_Have you read the [devfile registry contributing guide](https://github.com/devfile/registry/blob/main/CONTRIBUTING.md) and followed its instructions?_
- [x] Test automation
_Does this repository's tests pass with your changes?_
- [x] Documentation
_Does any documentation need to be updated with your changes?_
- [x] Check Tools Provider
_Have you tested the changes with existing tools, i.e. Odo, Che, Console? (See [devfile registry contributing guide](https://github.com/devfile/registry/blob/main/CONTRIBUTING.md) on how to test changes)_


### How to test changes / Special notes to the reviewer:
Tested on fork here: https://github.com/mike-hoang/registry/actions/runs/5334469263/jobs/9666282880

Diff from fork: https://github.com/mike-hoang/registry/commit/30784fea0a31dc16052b7cf053e7cae91ba4e643