### PR TITLE
use the force flag when removing minikube docker images

### DIFF
--- a/tests/check_non_terminating.sh
+++ b/tests/check_non_terminating.sh
@@ -108,12 +108,6 @@ isNonTerminating() {
     echo "  SUCCESS: The container started successfully and didn't terminate"
     kubectl delete pod test-terminating -n "${TEST_NAMESPACE}" >/dev/null 2>&1
 
-    # remove image to save space
-    if [ "$ENV" = "minikube" ]; then
-      echo "  COMMAND: \"minikube ssh docker image rm $_int_image\""
-      minikube ssh docker image rm $_int_image >/dev/null 2>&1
-    fi
-
     return 0
   else
     echo "  ERROR: Failed to reach \"Ready\" condition after $timeout_in_sec seconds"

--- a/tests/check_non_terminating.sh
+++ b/tests/check_non_terminating.sh
@@ -190,6 +190,12 @@ for stack in $STACKS; do
 
   isNonTerminating "${image}" "${command_string}" "${command_args_string}"
 
+  # remove image to save space
+  if [ "$ENV" = "minikube" ]; then
+    echo "  COMMAND: \"minikube ssh -- docker image rm ${image} --force\""
+    minikube ssh -- docker image rm ${image} --force >/dev/null 2>&1
+  fi
+
   echo "======================="
 done
 

--- a/tests/check_non_terminating.sh
+++ b/tests/check_non_terminating.sh
@@ -107,6 +107,13 @@ isNonTerminating() {
   if kubectl wait pods -n "${TEST_NAMESPACE}" test-terminating --for condition=Ready --timeout=${timeout_in_sec}s >/dev/null 2>&1; then
     echo "  SUCCESS: The container started successfully and didn't terminate"
     kubectl delete pod test-terminating -n "${TEST_NAMESPACE}" >/dev/null 2>&1
+
+    # remove image to save space
+    if [ "$ENV" = "minikube" ]; then
+      echo "  COMMAND: \"minikube ssh docker image rm $_int_image\""
+      minikube ssh docker image rm $_int_image >/dev/null 2>&1
+    fi
+
     return 0
   else
     echo "  ERROR: Failed to reach \"Ready\" condition after $timeout_in_sec seconds"


### PR DESCRIPTION
### What does this PR do?:
Removes the docker image as per the merged PR https://github.com/devfile/registry/pull/189. Adds the `--force` flag because there is occasionally a conflict when trying to do the removal.

```shell
COMMAND: "minikube ssh docker image rm registry.access.redhat.com/ubi8/nodejs-18:1-47.1684740189"

Error response from daemon: conflict: unable to remove repository reference "registry.access.redhat.com/ubi8/nodejs-18:1-47.1684740189" (must force) - container 2e45242f9811 is using its referenced image f77092719a71
```

### Which issue(s) this PR fixes:
https://github.com/devfile/api/issues/1135
related pr: https://github.com/devfile/registry/pull/189

### PR acceptance criteria:

- [x] Contributing guide
_Have you read the [devfile registry contributing guide](https://github.com/devfile/registry/blob/main/CONTRIBUTING.md) and followed its instructions?_
- [x] Test automation
_Does this repository's tests pass with your changes?_
- [x] Documentation
_Does any documentation need to be updated with your changes?_
- [x] Check Tools Provider
_Have you tested the changes with existing tools, i.e. Odo, Che, Console? (See [devfile registry contributing guide](https://github.com/devfile/registry/blob/main/CONTRIBUTING.md) on how to test changes)_


### How to test changes / Special notes to the reviewer:
Tested on fork: https://github.com/mike-hoang/registry/actions/runs/5347278812/jobs/9695514390
Diff from fork: https://github.com/mike-hoang/registry/commit/3ab266f8654e60107ff5f4c11f83346dbccf1dfa