### PR TITLE
update to Node.js stack to 18, change default

### DIFF
--- a/stacks/nodejs/3.0.0/devfile.yaml
+++ b/stacks/nodejs/3.0.0/devfile.yaml
@@ -1,0 +1,67 @@
+schemaVersion: 3.0.0
+metadata:
+  name: nodejs
+  displayName: Node.js Runtime
+  description: Node.js 18 application
+  icon: https://nodejs.org/static/images/logos/nodejs-new-pantone-black.svg
+  tags:
+    - Node.js
+    - Express
+    - ubi8
+  projectType: Node.js
+  language: JavaScript
+  version: 2.2.0
+starterProjects:
+  - name: nodejs-starter
+    git:
+      remotes:
+        origin: 'https://github.com/odo-devfiles/nodejs-ex.git'
+components:
+  - name: runtime
+    container:
+      image: registry.access.redhat.com/ubi8/nodejs-18:1-32
+      args: ['tail', '-f', '/dev/null']
+      memoryLimit: 1024Mi
+      mountSources: true
+      env:
+        - name: DEBUG_PORT
+          value: '5858'
+      endpoints:
+        - name: http-node
+          targetPort: 3000
+        - exposure: none
+          name: debug
+          targetPort: 5858
+commands:
+  - id: install
+    exec:
+      component: runtime
+      commandLine: npm install
+      workingDir: ${PROJECT_SOURCE}
+      group:
+        kind: build
+        isDefault: true
+  - id: run
+    exec:
+      component: runtime
+      commandLine: npm start
+      workingDir: ${PROJECT_SOURCE}
+      group:
+        kind: run
+        isDefault: true
+  - id: debug
+    exec:
+      component: runtime
+      commandLine: npm run debug
+      workingDir: ${PROJECT_SOURCE}
+      group:
+        kind: debug
+        isDefault: true
+  - id: test
+    exec:
+      component: runtime
+      commandLine: npm test
+      workingDir: ${PROJECT_SOURCE}
+      group:
+        kind: test
+        isDefault: true

--- a/stacks/nodejs/stack.yaml
+++ b/stacks/nodejs/stack.yaml
@@ -4,5 +4,6 @@ displayName: Node.js Runtime
 icon: https://nodejs.org/static/images/logos/nodejs-new-pantone-black.svg
 versions:
   - version: 2.1.1
-    default: true # should have one and only one default version
   - version: 2.2.0
+  - version: 3.0.0
+    default: true # should have one and only one default version


### PR DESCRIPTION
### What does this PR do?:

Node.js stack `version: 2.1.1` contained Node.js 16 Dockerfiles, which were updated to Node.js 18 in `version: 2.2.0`. I think this should have been a semver-major change because the same projects may no longer work due to changing the underlying runtime. I figured the best approach was to propose re-releasing (copy) the stack to `version: 3.0.0`. 

Node.js 16 is End-of-Life this September, so I also think it's appropriate to update the default. 

### Which issue(s) this PR fixes:

N/A

### PR acceptance criteria:

- [ ] Contributing guide
_Have you read the [devfile registry contributing guide](https://github.com/devfile/registry/blob/main/CONTRIBUTING.md) and followed its instructions?_
- [ ] Test automation
_Does this repository's tests pass with your changes?_
- [ ] Documentation
_Does any documentation need to be updated with your changes?_
- [ ] Check Tools Provider
_Have you tested the changes with existing tools, i.e. Odo, Che, Console? (See [devfile registry contributing guide](https://github.com/devfile/registry/blob/main/CONTRIBUTING.md) on how to test changes)_


### How to test changes / Special notes to the reviewer: