### PR TITLE
Generate namespace for every devfile samples in RHTAP cluster

### DIFF
--- a/tests/check_rhtap_nightly.sh
+++ b/tests/check_rhtap_nightly.sh
@@ -2,8 +2,15 @@
 
 set -x
 
-samplesFile="$(pwd)/extraDevfileEntries.yaml"
+ROOT_REPO_DIR=$(pwd)
+samplesFile="$ROOT_REPO_DIR/extraDevfileEntries.yaml"
 
-ginkgo run --procs 2 \
+# Install golang modules
+cd "$ROOT_REPO_DIR"/tests/rhtap && \
+    go mod tidy && \
+    go mod vendor && \
+    cd "$ROOT_REPO_DIR"
+
+ginkgo run -p \
   --timeout 2h \
   tests/rhtap -- -samplesFile "$samplesFile"

--- a/tests/rhtap/rhtap_test.go
+++ b/tests/rhtap/rhtap_test.go
@@ -32,7 +32,6 @@ func TestRhtap(t *testing.T) {
 
 var _ = Describe("RHTAP sample checks", Ordered, Label("nightly"), func() {
 	var fw *testHub.ControllerHub
-	var testNamespace string
 	component := &appservice.Component{}
 	cdq := &appservice.ComponentDetectionQuery{}
 
@@ -50,33 +49,31 @@ var _ = Describe("RHTAP sample checks", Ordered, Label("nightly"), func() {
 				Expect(err).NotTo(HaveOccurred())
 
 				// If not namespace specified creates one
-				if testNamespace == "" {
+				if namespace == "" {
 					ns, err := fw.CommonController.CreateTestNamespace(utils.GetGeneratedNamespace("stack"))
 					Expect(err).NotTo(HaveOccurred())
-					testNamespace = ns.Name
-				} else {
-					testNamespace = namespace
+					namespace = ns.Name
 				}
 			})
 
 			AfterAll(func() {
 				if !CurrentSpecReport().Failed() {
-					Expect(fw.HasController.DeleteAllApplicationsInASpecificNamespace(testNamespace, 30*time.Second)).To(Succeed())
+					Expect(fw.HasController.DeleteAllApplicationsInASpecificNamespace(namespace, 30*time.Second)).To(Succeed())
 				}
 			})
 
 			// Create an application in a specific namespace
 			It("creates an application", func() {
 				GinkgoWriter.Printf("Parallel process %d\n", GinkgoParallelProcess())
-				createdApplication, err := fw.HasController.CreateApplication(sampleEntry.Name, testNamespace)
+				createdApplication, err := fw.HasController.CreateApplication(sampleEntry.Name, namespace)
 				Expect(err).NotTo(HaveOccurred())
-				Expect(createdApplication.Namespace).To(Equal(testNamespace))
+				Expect(createdApplication.Namespace).To(Equal(namespace))
 			})
 
 			// Check the application health and check if a devfile was generated in the status
 			It("checks if application is healthy", func() {
 				Eventually(func() string {
-					application, err := fw.HasController.GetApplication(sampleEntry.Name, testNamespace)
+					application, err := fw.HasController.GetApplication(sampleEntry.Name, namespace)
 					Expect(err).NotTo(HaveOccurred())
 
 					return application.Status.Devfile
@@ -84,20 +81,20 @@ var _ = Describe("RHTAP sample checks", Ordered, Label("nightly"), func() {
 			})
 
 			It("creates componentdetectionquery", func() {
-				cdq, err = fw.HasController.CreateComponentDetectionQuery(sampleEntry.Name, testNamespace, sampleEntry.Git.Remotes.Origin, "", "", "", false)
+				cdq, err = fw.HasController.CreateComponentDetectionQuery(sampleEntry.Name, namespace, sampleEntry.Git.Remotes.Origin, "", "", "", false)
 				Expect(err).NotTo(HaveOccurred())
 			})
 
 			It("creates component", func() {
 				for _, compDetected := range cdq.Status.ComponentDetected {
-					component, err = fw.HasController.CreateComponent(compDetected.ComponentStub, testNamespace, "", "", sampleEntry.Name, true, map[string]string{})
+					component, err = fw.HasController.CreateComponent(compDetected.ComponentStub, namespace, "", "", sampleEntry.Name, true, map[string]string{})
 					Expect(err).NotTo(HaveOccurred())
 				}
 			})
 
 			// Start to watch the pipeline until is finished
 			It("waits component pipeline to be finished", func() {
-				component, err = fw.HasController.GetComponent(component.Name, testNamespace)
+				component, err = fw.HasController.GetComponent(component.Name, namespace)
 				Expect(err).ShouldNot(HaveOccurred(), "failed to get component: %v", err)
 
 				Expect(fw.HasController.WaitForComponentPipelineToBeFinished(component, "", 2)).To(Succeed())


### PR DESCRIPTION
This Pr create namespace for each devfile. to avoid tekton bug. See discussion: https://redhat-internal.slack.com/archives/C04GVLR0155/p1692087863337849