### PR TITLE
Rollback nodejs stack updates

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -32,7 +32,8 @@
       "stacks/java-openliberty/**",
       "stacks/java-openliberty-gradle/**",
       "stacks/java-websphereliberty/**",
-      "stacks/java-websphereliberty-gradle/**"
+      "stacks/java-websphereliberty-gradle/**",
+      "stacks/nodejs/**"
     ],
     "prHourlyLimit": 20,
     "prConcurrentLimit": 5

--- a/stacks/nodejs/2.1.1/devfile.yaml
+++ b/stacks/nodejs/2.1.1/devfile.yaml
@@ -19,7 +19,7 @@ starterProjects:
 components:
   - name: runtime
     container:
-      image: registry.access.redhat.com/ubi8/nodejs-16:1-105.1684740145
+      image: registry.access.redhat.com/ubi8/nodejs-16:latest
       args: ['tail', '-f', '/dev/null']
       memoryLimit: 1024Mi
       mountSources: true


### PR DESCRIPTION
### What does this PR do?:

As it is mentioned in the comment https://github.com/devfile/api/issues/1271#issuecomment-1738122163 the changes introduced by https://github.com/devfile/registry/pull/205 might causethe failure of the nightly run for registry. This PR reverts the updates brought by renovate config and also add a rule to exclude this stack for new updates.

### Which issue(s) this PR fixes:

fixes https://github.com/devfile/api/issues/1271

### PR acceptance criteria:

- [ ] Contributing guide
_Have you read the [devfile registry contributing guide](https://github.com/devfile/registry/blob/main/CONTRIBUTING.md) and followed its instructions?_
- [ ] Test automation
_Does this repository's tests pass with your changes?_
- [ ] Documentation
_Does any documentation need to be updated with your changes?_
- [ ] Check Tools Provider
_Have you tested the changes with existing tools, i.e. Odo, Che, Console? (See [devfile registry contributing guide](https://github.com/devfile/registry/blob/main/CONTRIBUTING.md) on how to test changes)_


### How to test changes / Special notes to the reviewer: