### PR TITLE
Make sure to run `odo` v3 tests for stacks that have no starter projects

### DIFF
--- a/.github/workflows/validate-stacks.yaml
+++ b/.github/workflows/validate-stacks.yaml
@@ -141,7 +141,7 @@ jobs:
       - name: Install odo v3
         uses: redhat-actions/openshift-tools-installer@2de9a80cf012ad0601021515481d433b91ef8fd5 # v1
         with:
-          odo: "3.2.0"
+          odo: "3.15.0"
 
       - name: Install Ginkgo
         run: go install -mod=mod github.com/onsi/ginkgo/v2/ginkgo@v2.5.0


### PR DESCRIPTION
### What does this PR do?:

/kind bug

This fixes the issue reported in https://github.com/devfile/api/issues/1103, where the `odo v3` tests would not run any tests on certain stacks.
The issue has been narrowed down to stacks that have no starter projects in their Devfiles, like [udi](https://github.com/devfile/registry/blob/main/stacks/udi/devfile.yaml).

This PR makes sure to test such stacks, by leveraging the [`odo dev --no-commands`](https://odo.dev/blog/odo-v3.12.0#full-control-over-the-application-lifecycle-with-odo-dev---no-commands-and-odo-run) command, to check that the Dev Session just starts properly.

### Which issue(s) this PR fixes:
Fixes https://github.com/devfile/api/issues/1103

### PR acceptance criteria:

- [x] Contributing guide
_Have you read the [devfile registry contributing guide](https://github.com/devfile/registry/blob/main/CONTRIBUTING.md) and followed its instructions?_
- [x] Test automation
_Does this repository's tests pass with your changes?_
- [ ] Documentation
_Does any documentation need to be updated with your changes?_
- [ ] Check Tools Provider
_Have you tested the changes with existing tools, i.e. Odo, Che, Console? (See [devfile registry contributing guide](https://github.com/devfile/registry/blob/main/CONTRIBUTING.md) on how to test changes)_

### How to test changes / Special notes to the reviewer: