### PR TITLE
Update http-python and http-springboot endpoints to 8082

### DIFF
--- a/stacks/java-springboot/2.0.0/devfile.yaml
+++ b/stacks/java-springboot/2.0.0/devfile.yaml
@@ -25,7 +25,7 @@ components:
       mountSources: true
       endpoints:
         - name: http-springboot
-          targetPort: 8080
+          targetPort: 8082
         - exposure: none
           name: debug
           targetPort: 5858

--- a/stacks/python/3.0.0/devfile.yaml
+++ b/stacks/python/3.0.0/devfile.yaml
@@ -29,7 +29,7 @@ components:
       mountSources: true
       endpoints:
         - name: http-python
-          targetPort: 8080
+          targetPort: 8082
         - exposure: none
           name: debug
           targetPort: 5858


### PR DESCRIPTION
### What does this PR do?:

This PR is related to the DEVHAS-423 and tries to update the `http-python` in order to be use port `8082` instead of port `8080`. As a result, we will be able to create new version of `python sample` which will expose `8080` and all samples will be consistent.

### Which issue(s) this PR fixes:

https://issues.redhat.com/browse/DEVHAS-423

### PR acceptance criteria:

- [x] Contributing guide
_Have you read the [devfile registry contributing guide](https://github.com/devfile/registry/blob/main/CONTRIBUTING.md) and followed its instructions?_
- [x] Test automation
_Does this repository's tests pass with your changes?_
- [x] Documentation
_Does any documentation need to be updated with your changes?_
- [x] Check Tools Provider
_Have you tested the changes with existing tools, i.e. Odo, Che, Console? (See [devfile registry contributing guide](https://github.com/devfile/registry/blob/main/CONTRIBUTING.md) on how to test changes)_


### How to test changes / Special notes to the reviewer: