### PR TITLE
Extend gitSignOff

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -2,7 +2,8 @@
     "$schema": "https://docs.renovatebot.com/renovate-schema.json",
     "extends": [
       "config:base",
-      "helpers:pinGitHubActionDigests"
+      "helpers:pinGitHubActionDigests",
+      ":gitSignOff"
     ],
     "enabledManagers": ["regex", "github-actions"],
     "regexManagers": [


### PR DESCRIPTION
### What does this PR do?:

This PR fixes the failure in the DCO check for renovate PRs. In order to do so, it extends the `:gitSignOff` preset of renovate configuration. You can check more info about the proposed workaround [here](https://docs.renovatebot.com/configuration-options/#commitbody)

### Which issue(s) this PR fixes:

fixes https://github.com/devfile/api/issues/1280

### PR acceptance criteria:

- [x] Contributing guide
_Have you read the [devfile registry contributing guide](https://github.com/devfile/registry/blob/main/CONTRIBUTING.md) and followed its instructions?_
- [x] Test automation
_Does this repository's tests pass with your changes?_
- [x] Documentation
_Does any documentation need to be updated with your changes?_
- [x] Check Tools Provider
_Have you tested the changes with existing tools, i.e. Odo, Che, Console? (See [devfile registry contributing guide](https://github.com/devfile/registry/blob/main/CONTRIBUTING.md) on how to test changes)_


### How to test changes / Special notes to the reviewer: