### PR TITLE
Copy additional stack resources inside tmpDir before validating stacks with odov3

### DIFF
--- a/tests/odov3/types.go
+++ b/tests/odov3/types.go
@@ -33,6 +33,7 @@ type Stack struct {
 	name            string
 	version         string
 	path            string
+	base            string
 	starterProjects []v1alpha2.StarterProject
 }
 


### PR DESCRIPTION
### What does this PR do?:

This PR tries to copy all additional resources found inside a stack after `odo init --devfile-path`. This way we are able to use `odo init` in an empty directory and run `odo dev` with all the resources required.

### Which issue(s) this PR fixes:

fixes https://github.com/devfile/api/issues/1288

### PR acceptance criteria:

- [x] Contributing guide
_Have you read the [devfile registry contributing guide](https://github.com/devfile/registry/blob/main/CONTRIBUTING.md) and followed its instructions?_
- [x] Test automation
_Does this repository's tests pass with your changes?_
- [x] Documentation
_Does any documentation need to be updated with your changes?_
- [x] Check Tools Provider
_Have you tested the changes with existing tools, i.e. Odo, Che, Console? (See [devfile registry contributing guide](https://github.com/devfile/registry/blob/main/CONTRIBUTING.md) on how to test changes)_


### How to test changes / Special notes to the reviewer: