### PR TITLE
Increase java-quarkus container memory limit

### DIFF
--- a/stacks/java-quarkus/devfile.yaml
+++ b/stacks/java-quarkus/devfile.yaml
@@ -23,7 +23,7 @@ components:
     container:
       image: registry.access.redhat.com/ubi8/openjdk-17:1.16-1
       args: ['tail', '-f', '/dev/null']
-      memoryLimit: 512Mi ## default app nowhere needs this but leaving room for expansion.
+      memoryLimit: 1024Mi ## default app nowhere needs this but leaving room for expansion.
       mountSources: true
       volumeMounts:
         - name: m2


### PR DESCRIPTION
### What does this PR do?:

As it is mentioned in https://github.com/devfile/api/issues/1293 the checks of `odov3` and `odov2` are failing because we reach the memory limit of the container when we are trying to build the quarkus application.

I've managed to fix this issue by increasing the component memory limit to `1024Mi`.

### Which issue(s) this PR fixes:

fixes https://github.com/devfile/api/issues/1293

### PR acceptance criteria:

- [x] Contributing guide
_Have you read the [devfile registry contributing guide](https://github.com/devfile/registry/blob/main/CONTRIBUTING.md) and followed its instructions?_
- [x] Test automation
_Does this repository's tests pass with your changes?_
- [x] Documentation
_Does any documentation need to be updated with your changes?_
- [x] Check Tools Provider
_Have you tested the changes with existing tools, i.e. Odo, Che, Console? (See [devfile registry contributing guide](https://github.com/devfile/registry/blob/main/CONTRIBUTING.md) on how to test changes)_


### How to test changes / Special notes to the reviewer:

You can reproduce and test the fix by running locally the `test/check_odov2.sh` (the instructions are in the bug issue)