### PR TITLE
Add schedule and timezone to renovate.json

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -5,6 +5,8 @@
       "helpers:pinGitHubActionDigests",
       ":gitSignOff"
     ],
+    "timezone": "America/Toronto",
+    "schedule": ["on the 2nd and 4th day instance on thursday after 9pm"],
     "enabledManagers": ["regex", "github-actions"],
     "regexManagers": [
       {


### PR DESCRIPTION
### What does this PR do?:

This PR updates the schedule of the renovate.json file. The new schedule will run renovate on the 2nd and 4th Thursday of the month after 9pm (america/toronto time)

### Which issue(s) this PR fixes:

N/A

### PR acceptance criteria:

- [ ] Contributing guide
_Have you read the [devfile registry contributing guide](https://github.com/devfile/registry/blob/main/CONTRIBUTING.md) and followed its instructions?_
- [ ] Test automation
_Does this repository's tests pass with your changes?_
- [ ] Documentation
_Does any documentation need to be updated with your changes?_
- [ ] Check Tools Provider
_Have you tested the changes with existing tools, i.e. Odo, Che, Console? (See [devfile registry contributing guide](https://github.com/devfile/registry/blob/main/CONTRIBUTING.md) on how to test changes)_


### How to test changes / Special notes to the reviewer: