### PR TITLE
Add podman support for the build and deploy scripts

### DIFF
--- a/.ci/build.sh
+++ b/.ci/build.sh
@@ -14,10 +14,11 @@
 #   limitations under the License.
 
 ABSOLUTE_PATH="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+CONTAINER_ENGINE=${CONTAINER_ENGINE:-docker}
 
 if [ $# -eq 1 ] && [ $1 == "offline" ]
 then
-    docker build --no-cache -t devfile-index -f $ABSOLUTE_PATH/Dockerfile.offline $ABSOLUTE_PATH/..
+    ${CONTAINER_ENGINE} build --no-cache -t devfile-index -f $ABSOLUTE_PATH/Dockerfile.offline $ABSOLUTE_PATH/..
 else
-    docker build --no-cache -t devfile-index -f $ABSOLUTE_PATH/Dockerfile $ABSOLUTE_PATH/..
+    ${CONTAINER_ENGINE} build --no-cache -t devfile-index -f $ABSOLUTE_PATH/Dockerfile $ABSOLUTE_PATH/..
 fi

--- a/.ci/build.sh
+++ b/.ci/build.sh
@@ -12,13 +12,19 @@
 #   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 #   See the License for the specific language governing permissions and
 #   limitations under the License.
+shopt -s expand_aliases
 
 ABSOLUTE_PATH="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
-CONTAINER_ENGINE=${CONTAINER_ENGINE:-docker}
+USE_PODMAN=${USE_PODMAN:-false}
+
+if [[ ${USE_PODMAN} == true ]]; then
+    alias docker=podman
+    echo "using podman as container engine"
+fi
 
 if [ $# -eq 1 ] && [ $1 == "offline" ]
 then
-    ${CONTAINER_ENGINE} build --no-cache -t devfile-index -f $ABSOLUTE_PATH/Dockerfile.offline $ABSOLUTE_PATH/..
+    docker build --no-cache -t devfile-index -f $ABSOLUTE_PATH/Dockerfile.offline $ABSOLUTE_PATH/..
 else
-    ${CONTAINER_ENGINE} build --no-cache -t devfile-index -f $ABSOLUTE_PATH/Dockerfile $ABSOLUTE_PATH/..
+    docker build --no-cache -t devfile-index -f $ABSOLUTE_PATH/Dockerfile $ABSOLUTE_PATH/..
 fi

--- a/.ci/build_and_deploy.sh
+++ b/.ci/build_and_deploy.sh
@@ -18,6 +18,15 @@ GIT_REV="$(git rev-parse --short=7 HEAD)"
 INDEX_IMAGE="${INDEX_IMAGE:-quay.io/app-sre/devfile-index}"
 VIEWER_IMAGE="${VIEWER_IMAGE:-quay.io/app-sre/registry-viewer}"
 IMAGE_TAG="${IMAGE_TAG:-${GIT_REV}}"
+CONTAINER_ENGINE=${CONTAINER_ENGINE:-docker}
+# Use of this env variable is required for the devfile-web build script
+USE_PODMAN=${USE_PODMAN:-false}
+
+# Ensure container engine is set properly for devfile-web scripts
+if [[ ${CONTAINER_ENGINE} == "podman" ]]; then
+    USE_PODMAN=true
+    echo "using podman as container engine"
+fi
 
 # Run the build script
 bash $ABSOLUTE_PATH/build.sh
@@ -29,6 +38,11 @@ then
 fi
 git clone https://github.com/devfile/devfile-web.git $ABSOLUTE_PATH/devfile-web
 
+# devfile-web scripts require the USE_PODMAN env variable in order to work
+cd $ABSOLUTE_PATH/devfile-web
+export USE_PODMAN=${USE_PODMAN}
+cd ..
+
 # Build registry-viewer
 bash $ABSOLUTE_PATH/devfile-web/scripts/build_viewer.sh
 
@@ -38,17 +52,17 @@ if [[ -n "$QUAY_USER" && -n "$QUAY_TOKEN" ]]; then
     mkdir -p "$DOCKER_CONF"
 
     # login into quay.io
-    docker --config="$DOCKER_CONF" login -u="$QUAY_USER" -p="$QUAY_TOKEN" quay.io
+    ${CONTAINER_ENGINE} --config="$DOCKER_CONF" login -u="$QUAY_USER" -p="$QUAY_TOKEN" quay.io
 
     # devfile-index
-    docker tag devfile-index "${INDEX_IMAGE}:${IMAGE_TAG}"
-    docker tag devfile-index "${INDEX_IMAGE}:next"
-    docker --config="$DOCKER_CONF" push "${INDEX_IMAGE}:${IMAGE_TAG}"
-    docker --config="$DOCKER_CONF" push "${INDEX_IMAGE}:next"
+    ${CONTAINER_ENGINE} tag devfile-index "${INDEX_IMAGE}:${IMAGE_TAG}"
+    ${CONTAINER_ENGINE} tag devfile-index "${INDEX_IMAGE}:next"
+    ${CONTAINER_ENGINE} --config="$DOCKER_CONF" push "${INDEX_IMAGE}:${IMAGE_TAG}"
+    ${CONTAINER_ENGINE} --config="$DOCKER_CONF" push "${INDEX_IMAGE}:next"
 
     # registry-viewer
-    docker tag registry-viewer "${VIEWER_IMAGE}:${IMAGE_TAG}"
-    docker tag registry-viewer "${VIEWER_IMAGE}:next"
-    docker --config="$DOCKER_CONF" push "${VIEWER_IMAGE}:${IMAGE_TAG}"
-    docker --config="$DOCKER_CONF" push "${VIEWER_IMAGE}:next"
+    ${CONTAINER_ENGINE} tag registry-viewer "${VIEWER_IMAGE}:${IMAGE_TAG}"
+    ${CONTAINER_ENGINE} tag registry-viewer "${VIEWER_IMAGE}:next"
+    ${CONTAINER_ENGINE} --config="$DOCKER_CONF" push "${VIEWER_IMAGE}:${IMAGE_TAG}"
+    ${CONTAINER_ENGINE} --config="$DOCKER_CONF" push "${VIEWER_IMAGE}:next"
 fi

--- a/.ci/build_and_deploy.sh
+++ b/.ci/build_and_deploy.sh
@@ -37,11 +37,6 @@ then
 fi
 git clone https://github.com/devfile/devfile-web.git $ABSOLUTE_PATH/devfile-web
 
-# devfile-web scripts require the USE_PODMAN env variable in order to work
-# cd $ABSOLUTE_PATH/devfile-web
-# export USE_PODMAN=${USE_PODMAN}
-# cd ..
-
 # Build registry-viewer
 bash $ABSOLUTE_PATH/devfile-web/scripts/build_viewer.sh
 

--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ If you are a stack owner and need to request an urgent refresh of <https://regis
 
 ### Build
 
-To build this devfile registry into a container image run `bash .ci/build.sh`. A container image will be built using the [devfile registry build tools](https://github.com/devfile/registry-support/tree/master/build-tools). By default these scripts will use `docker`, if you want to use podman you should first run `export USE_PODMAN=true` before executing the build script.
+To build this devfile registry into a container image run `bash .ci/build.sh`. A container image will be built using the [devfile registry build tools](https://github.com/devfile/registry-support/tree/master/build-tools). By default these scripts will use `docker`, if you want to use `podman` you should first run `export USE_PODMAN=true` before executing the build script.
 
 From there, push the container image to a container registry of your choice and deploy using one of the methods outlined [here](https://github.com/devfile/registry-support#deploy).
 

--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ If you are a stack owner and need to request an urgent refresh of <https://regis
 
 ### Build
 
-To build this devfile registry into a container image run `bash .ci/build.sh`. A container image will be built using the [devfile registry build tools](https://github.com/devfile/registry-support/tree/master/build-tools). By default these scripts will use `docker`, if you want to use podman first run `export CONTAINER_ENGINE=podman` before executing the build script.
+To build this devfile registry into a container image run `bash .ci/build.sh`. A container image will be built using the [devfile registry build tools](https://github.com/devfile/registry-support/tree/master/build-tools). By default these scripts will use `docker`, if you want to use podman you should first run `export USE_PODMAN=true` before executing the build script.
 
 From there, push the container image to a container registry of your choice and deploy using one of the methods outlined [here](https://github.com/devfile/registry-support#deploy).
 

--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ If you are a stack owner and need to request an urgent refresh of <https://regis
 
 ### Build
 
-To build this devfile registry into a container image run `bash .ci/build.sh`. A container image will be built using the [devfile registry build tools](https://github.com/devfile/registry-support/tree/master/build-tools).
+To build this devfile registry into a container image run `bash .ci/build.sh`. A container image will be built using the [devfile registry build tools](https://github.com/devfile/registry-support/tree/master/build-tools). By default these scripts will use `docker`, if you want to use podman first run `export CONTAINER_ENGINE=podman` before executing the build script.
 
 From there, push the container image to a container registry of your choice and deploy using one of the methods outlined [here](https://github.com/devfile/registry-support#deploy).
 


### PR DESCRIPTION
### What does this PR do?:
_Summarize the changes. Are any stacks or samples added or updated?_

This PR allows the use of podman as a container engine to run the build and deploy scripts.

### Which issue(s) this PR fixes:
_Link to github issue(s)_
resolves https://github.com/devfile/api/issues/1339
### PR acceptance criteria:

- [ ] Implement podman support for development so contributors are not forced to use docker.
- [ ] Update documentation to reflect changes in the build/deploy process.
- [ ] Sufficiently test changes made.

### How to test changes / Special notes to the reviewer:
To run the scripts with `docker` you can run them normally with `bash .ci/build.sh` and `bash .ci/build_and_deploy.sh`. In order to test that podman support works first run `export USE_PODMAN=true` and then either `bash .ci/build.sh` or `bash .ci/build_and_deploy.sh`.