### PR TITLE
Disable automerge from renovate bot

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -24,7 +24,9 @@
           "matchManagers": ["github-actions"],
           "groupName": "github actions",
           "groupSlug": "github-actions",
-          "commitMessageTopic": "{{depName}}"
+          "commitMessageTopic": "{{depName}}",
+          "automerge": false,
+          "platformAutomerge": false
         },
         {
           "description": "Disable grouping patch and digest updates",


### PR DESCRIPTION
### What does this PR do?:

This PR simply overrides the configuration from the platform engineering bot here: https://github.com/platform-engineering-org/.github/blob/main/default.json#L19-L20 in order to disable `automerge` from the bot.

### Which issue(s) this PR fixes:
_Link to github issue(s)_

### PR acceptance criteria:

- [ ] Contributing guide
_Have you read the [devfile registry contributing guide](https://github.com/devfile/registry/blob/main/CONTRIBUTING.md) and followed its instructions?_
- [ ] Test automation
_Does this repository's tests pass with your changes?_
- [ ] Documentation
_Does any documentation need to be updated with your changes?_
- [ ] Check Tools Provider
_Have you tested the changes with existing tools, i.e. Odo, Che, Console? (See [devfile registry contributing guide](https://github.com/devfile/registry/blob/main/CONTRIBUTING.md) on how to test changes)_


### How to test changes / Special notes to the reviewer: