### PR TITLE
Updated devfile.yaml

### DIFF
--- a/stacks/python/3.0.0/devfile.yaml
+++ b/stacks/python/3.0.0/devfile.yaml
@@ -29,7 +29,7 @@ components:
       mountSources: true
       endpoints:
         - name: http-python
-          targetPort: 8080
+          targetPort: 8081
         - exposure: none
           name: debug
           targetPort: 5858


### PR DESCRIPTION
### What does this PR do?:
_Summarize the changes. Are any stacks or samples added or updated?_
This PR addresses the inconsistency in port numbers between the [devfile.yaml](https://github.com/devfile/registry/blob/4e7b4782b2a49874cc73ff6537544f71288d2874/stacks/python/3.0.0/devfile.yaml#L33) file and the corresponding Kubernetes deployment in the Python 3.0.0 stack. The `targetPort` for the `http-python` endpoint in the [devfile.yaml](https://github.com/devfile/registry/blob/4e7b4782b2a49874cc73ff6537544f71288d2874/stacks/python/3.0.0/devfile.yaml#L33) is updated to align with the Kubernetes deployment, resolving the issue.

### Which issue(s) this PR fixes:
_Link to github issue(s)_
https://github.com/devfile/api/issues/998
### PR acceptance criteria:

- [ ] Contributing guide
_Have you read the [devfile registry contributing guide](https://github.com/devfile/registry/blob/main/CONTRIBUTING.md) and followed its instructions?_
- [ ] Test automation
_Does this repository's tests pass with your changes?_
- [ ] Documentation
_Does any documentation need to be updated with your changes?_
- [ ] Check Tools Provider
_Have you tested the changes with existing tools, i.e. Odo, Che, Console? (See [devfile registry contributing guide](https://github.com/devfile/registry/blob/main/CONTRIBUTING.md) on how to test changes)_



### How to test changes / Special notes to the reviewer: