### PR TITLE
Add sample versions in extraDevfileEntries.yaml

### DIFF
--- a/extraDevfileEntries.yaml
+++ b/extraDevfileEntries.yaml
@@ -10,9 +10,14 @@ samples:
     projectType: Node.js
     language: JavaScript
     provider: Red Hat
-    git:
-      remotes:
-        origin: https://github.com/nodeshift-starters/devfile-sample.git
+    versions:
+      - version: 3.0.0
+        default: true
+        schemaVersion: 2.2.0
+        git:
+          revision: main
+          remotes:
+            origin: https://github.com/nodeshift-starters/devfile-sample.git
   - name: code-with-quarkus
     displayName: Basic Quarkus
     description: Java Quarkus application using Maven 4.0 and OpenJDK 17
@@ -23,9 +28,14 @@ samples:
     projectType: Quarkus
     language: Java
     provider: Red Hat
-    git:
-      remotes:
-        origin: https://github.com/devfile-samples/devfile-sample-code-with-quarkus.git
+    versions:
+      - version: 1.2.1
+        default: true
+        schemaVersion: 2.2.0
+        git:
+          revision: main
+          remotes:
+            origin: https://github.com/devfile-samples/devfile-sample-code-with-quarkus.git
   - name: java-springboot-basic
     displayName: Basic Spring Boot
     description: Java Spring Boot application using Maven 4.0 and OpenJDK 17
@@ -36,9 +46,20 @@ samples:
     projectType: springboot
     language: Java
     provider: Red Hat
-    git:
-      remotes:
-        origin: https://github.com/devfile-samples/devfile-sample-java-springboot-basic.git
+    versions:
+      - version: 1.2.1
+        default: true
+        schemaVersion: 2.2.0
+        git:
+          revision: main
+          remotes:
+            origin: https://github.com/devfile-samples/devfile-sample-java-springboot-basic.git
+      - version: 2.0.0
+        schemaVersion: 2.2.0
+        git:
+          revision: v2.0.0
+          remotes:
+            origin: https://github.com/devfile-samples/devfile-sample-java-springboot-basic.git
   - name: python-basic
     displayName: Basic Python
     description: Python 3.9.x application with Flask
@@ -50,9 +71,20 @@ samples:
     projectType: Python
     language: Python
     provider: Red Hat
-    git:
-      remotes:
-        origin: https://github.com/devfile-samples/devfile-sample-python-basic.git
+    versions:
+      - version: 1.0.1
+        default: true
+        schemaVersion: 2.2.0
+        git:
+          revision: main
+          remotes:
+            origin: https://github.com/devfile-samples/devfile-sample-python-basic.git
+      - version: 2.0.0
+        schemaVersion: 2.2.0
+        git:
+          revision: v2.0.0
+          remotes:
+            origin: https://github.com/devfile-samples/devfile-sample-python-basic.git
   - name: go-basic
     displayName: Basic Go
     description: Go 1.16 application
@@ -62,9 +94,20 @@ samples:
     projectType: Go
     language: Go
     provider: Red Hat
-    git:
-      remotes:
-        origin: https://github.com/devfile-samples/devfile-sample-go-basic.git
+    versions:
+      - version: 1.1.0
+        default: true
+        schemaVersion: 2.2.0
+        git:
+          revision: main
+          remotes:
+            origin: https://github.com/devfile-samples/devfile-sample-go-basic.git
+      - version: 2.0.0
+        schemaVersion: 2.2.0
+        git:
+          revision: v2.0.0
+          remotes:
+            origin: https://github.com/devfile-samples/devfile-sample-go-basic.git
   - name: dotnet-basic
     displayName: Basic .NET
     description: MVC .NET 6.0 application
@@ -74,6 +117,11 @@ samples:
     projectType: dotnet
     language: .NET
     provider: Red Hat
-    git:
-      remotes:
-        origin: https://github.com/devfile-samples/devfile-sample-dotnet60-basic.git
+    versions:
+      - version: 1.1.1
+        default: true
+        schemaVersion: 2.2.0
+        git:
+          revision: main
+          remotes:
+            origin: https://github.com/devfile-samples/devfile-sample-dotnet60-basic.git


### PR DESCRIPTION
### What does this PR do?:

This PR is the last step to the support of multiple sample versions inside the `extraDevfileEntries.yaml`. This feature will allow us to support samples with parents using outerloop and to have more consistent ports.

As a result all entries inside the `extraDevfileEntries.yaml` have been updated to have versions. Other than that the 3 samples that have a parent supporting outerloop now have an extra version. Those are:

* `go-basic`: We have added version `2.0.0` in order to support the outerloop `go` stack versions.
* `python-basic`: We have added version `2.0.0` in order to support the outerloop `python` stack versions.
* `java-springboot-basic`: We have added version `2.0.0` in order to support the outerloop `java-springboot` stack versions.

### Which issue(s) this PR fixes:

fixes https://github.com/devfile/api/issues/1112

### PR acceptance criteria:

- [x] Contributing guide
_Have you read the [devfile registry contributing guide](https://github.com/devfile/registry/blob/main/CONTRIBUTING.md) and followed its instructions?_
- [x] Test automation
_Does this repository's tests pass with your changes?_
- [x] Documentation
_Does any documentation need to be updated with your changes?_
- [x] Check Tools Provider
_Have you tested the changes with existing tools, i.e. Odo, Che, Console? (See [devfile registry contributing guide](https://github.com/devfile/registry/blob/main/CONTRIBUTING.md) on how to test changes)_


### How to test changes / Special notes to the reviewer:

Some notes for the consumers of the registry:

* `ODC` is using the `/index/sample` endpoint which will only return the default (old) versions of each sample.
* `RHTAP`  is using the `/index/sample` endpoint which will only return the default (old) versions of each sample.
* `odo` is not using the devfile samples.

For `RHTAP` I've tried to update locally the [mock-devfile-data.ts](https://github.com/openshift/hac-dev/blob/main/src/utils/__data__/mock-devfile-data.ts) with the updated `index/sample` (only the `git.revision` is added) and ran the tests. The tests were ok.

For `ODC` I've started a console server locally (CRC) using minikube & a build of the updated registry.