### PR TITLE
Create go 1.20 stack version

### DIFF
--- a/stacks/go/1.3.0/devfile.yaml
+++ b/stacks/go/1.3.0/devfile.yaml
@@ -1,0 +1,76 @@
+schemaVersion: 2.1.0
+metadata:
+  name: go
+  displayName: Go Runtime
+  description: Go (version 1.20.x) is an open source programming language that makes it easy to build simple, reliable, and efficient software.
+  icon: https://raw.githubusercontent.com/devfile-samples/devfile-stack-icons/main/golang.svg
+  tags:
+    - Go
+  projectType: Go
+  language: Go
+  provider: Red Hat
+  version: 1.3.0
+starterProjects:
+  - name: go-starter
+    description: A Go project with a simple HTTP server
+    git:
+      checkoutFrom:
+        revision: main
+      remotes:
+        origin: https://github.com/devfile-samples/devfile-stack-go.git
+components:
+  - container:
+      endpoints:
+        - name: http-go
+          targetPort: 8080
+        - exposure: none
+          name: debug
+          targetPort: 5858
+      image: registry.access.redhat.com/ubi9/go-toolset:1.20.10-2.1699551725
+      args: ["tail", "-f", "/dev/null"]
+      env:
+        - name: DEBUG_PORT
+          value: '5858'
+      memoryLimit: 1024Mi
+      mountSources: true
+    name: runtime
+commands:
+  - exec:
+      env:
+        - name: GOPATH
+          value: ${PROJECT_SOURCE}/.go
+        - name: GOCACHE
+          value: ${PROJECT_SOURCE}/.cache
+      commandLine: go build main.go
+      component: runtime
+      group:
+        isDefault: true
+        kind: build
+      workingDir: ${PROJECT_SOURCE}
+    id: build
+  - exec:
+      commandLine: ./main
+      component: runtime
+      group:
+        isDefault: true
+        kind: run
+      workingDir: ${PROJECT_SOURCE}
+    id: run
+
+  - exec:
+      commandLine: |
+        GOPATH=${PROJECT_SOURCE}/.go \
+        GOCACHE=${PROJECT_SOURCE}/.cache \
+        dlv \
+          --listen=127.0.0.1:${DEBUG_PORT} \
+          --only-same-user=false \
+          --headless=true \
+          --api-version=2 \
+          --accept-multiclient \
+          debug --continue main.go
+      component: runtime
+      group:
+        isDefault: true
+        kind: debug
+      workingDir: ${PROJECT_SOURCE}
+    id: debug

--- a/stacks/go/2.3.0/devfile.yaml
+++ b/stacks/go/2.3.0/devfile.yaml
@@ -1,0 +1,103 @@
+schemaVersion: 2.2.0
+metadata:
+  name: go
+  displayName: Go Runtime
+  description: Go (version 1.20.x) is an open source programming language that makes it easy to build simple, reliable, and efficient software.
+  icon: https://raw.githubusercontent.com/devfile-samples/devfile-stack-icons/main/golang.svg
+  tags:
+    - Go
+  projectType: Go
+  language: Go
+  provider: Red Hat
+  version: 2.3.0
+starterProjects:
+  - name: go-starter
+    description: A Go project with a simple HTTP server
+    git:
+      checkoutFrom:
+        revision: main
+      remotes:
+        origin: https://github.com/devfile-samples/devfile-stack-go.git
+components:
+  - name: build
+    image:
+      imageName: go-image:latest
+      dockerfile:
+        uri: docker/Dockerfile
+        buildContext: .
+        rootRequired: false
+  - name: deploy
+    kubernetes:
+      uri: kubernetes/deploy.yaml
+      endpoints:
+      - name: http-8081
+        targetPort: 8081
+  - container:
+      endpoints:
+        - name: http-go
+          targetPort: 8080
+        - exposure: none
+          name: debug
+          targetPort: 5858
+      image: registry.access.redhat.com/ubi9/go-toolset:1.20.10-2.1699551725
+      args: ['tail', '-f', '/dev/null']
+      env:
+        - name: DEBUG_PORT
+          value: '5858'
+      memoryLimit: 1024Mi
+      mountSources: true
+    name: runtime
+commands:
+  - id: build-image
+    apply:
+      component: build
+  - id: deployk8s
+    apply:
+      component: deploy
+  - id: deploy
+    composite:
+      commands:
+        - build-image
+        - deployk8s
+      group:
+        kind: deploy
+        isDefault: true
+  - exec:
+      env:
+        - name: GOPATH
+          value: ${PROJECT_SOURCE}/.go
+        - name: GOCACHE
+          value: ${PROJECT_SOURCE}/.cache
+      commandLine: go build main.go
+      component: runtime
+      group:
+        isDefault: true
+        kind: build
+      workingDir: ${PROJECT_SOURCE}
+    id: build
+  - exec:
+      commandLine: ./main
+      component: runtime
+      group:
+        isDefault: true
+        kind: run
+      workingDir: ${PROJECT_SOURCE}
+    id: run
+
+  - exec:
+      commandLine: |
+        GOPATH=${PROJECT_SOURCE}/.go \
+        GOCACHE=${PROJECT_SOURCE}/.cache \
+        dlv \
+          --listen=127.0.0.1:${DEBUG_PORT} \
+          --only-same-user=false \
+          --headless=true \
+          --api-version=2 \
+          --accept-multiclient \
+          debug --continue main.go
+      component: runtime
+      group:
+        isDefault: true
+        kind: debug
+      workingDir: ${PROJECT_SOURCE}
+    id: debug

--- a/stacks/go/2.3.0/docker/Dockerfile
+++ b/stacks/go/2.3.0/docker/Dockerfile
@@ -1,0 +1,12 @@
+FROM registry.access.redhat.com/ubi9/go-toolset:1.20.10-2.1699551725
+
+COPY go.mod ./
+RUN go mod download
+
+COPY *.go ./
+
+RUN go build -o ./main
+
+EXPOSE 8081
+
+CMD [ "./main" , "-p=8081"]

--- a/stacks/go/2.3.0/kubernetes/deploy.yaml
+++ b/stacks/go/2.3.0/kubernetes/deploy.yaml
@@ -1,0 +1,41 @@
+kind: Service
+apiVersion: v1
+metadata:
+  name: my-go-svc
+spec:
+  ports:
+    - name: http-8081
+      port: 8081
+      protocol: TCP
+      targetPort: 8081
+  selector:
+    app: go-app
+---
+kind: Deployment
+apiVersion: apps/v1
+metadata:
+  name: my-go
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: go-app
+  template:
+    metadata:
+      labels:
+        app: go-app
+    spec:
+      containers:
+        - name: my-go
+          image: go-image:latest
+          ports:
+            - name: http
+              containerPort: 8081
+              protocol: TCP
+          resources:
+            requests:
+              memory: "10Mi"
+              cpu: "10m"
+            limits:
+              memory: "100Mi"
+              cpu: "100m"

--- a/stacks/go/stack.yaml
+++ b/stacks/go/stack.yaml
@@ -14,3 +14,5 @@ versions:
   - version: 2.1.0
   # 2.2.0: debug command via dlv & go 1.19
   - version: 2.2.0
+  # 2.3.0: debug command via dlv & go 1.20
+  - version: 2.3.0

--- a/stacks/go/stack.yaml
+++ b/stacks/go/stack.yaml
@@ -9,6 +9,8 @@ versions:
   # 1.2.0: debug command via dlv & go 1.19
   - version: 1.2.0
     default: true # should have one and only one default version
+  # 1.3.0: debug command via dlv & go 1.20
+  - version: 1.3.0
   - version: 2.0.0
   # 2.1.0: debug command via dlv
   - version: 2.1.0


### PR DESCRIPTION
### What does this PR do?:
_Summarize the changes. Are any stacks or samples added or updated?_

This adds a new stack that supports Go version 1.20.x. This is done by adding version `2.3.0`

### Which issue(s) this PR fixes:
_Link to github issue(s)_

resolves https://github.com/devfile/api/issues/1316
### PR acceptance criteria:

- [x] Contributing guide
_Have you read the [devfile registry contributing guide](https://github.com/devfile/registry/blob/main/CONTRIBUTING.md) and followed its instructions?_
- [x] Test automation
_Does this repository's tests pass with your changes?_
- [x] Documentation
_Does any documentation need to be updated with your changes?_
- [x] Check Tools Provider
_Have you tested the changes with existing tools, i.e. Odo, Che, Console? (See [devfile registry contributing guide](https://github.com/devfile/registry/blob/main/CONTRIBUTING.md) on how to test changes)_


### How to test changes / Special notes to the reviewer: