### PR TITLE
Add sample version support on rhtap nightly

### DIFF
--- a/tests/rhtap/rhtap_test.go
+++ b/tests/rhtap/rhtap_test.go
@@ -87,8 +87,14 @@ var _ = Describe("RHTAP sample checks", Ordered, Label("nightly"), func() {
 			})
 
 			It("creates componentdetectionquery", func() {
-				cdq, err = fw.HasController.CreateComponentDetectionQuery(sampleEntry.Name, testNamespace, sampleEntry.Git.Remotes.Origin, "", "", "", false)
-				Expect(err).NotTo(HaveOccurred())
+				for _, sampleEntryVersion := range sampleEntry.Versions {
+					if sampleEntryVersion.Default {
+						sampleEntryGit := sampleEntryVersion.Git.Remotes.Origin
+						cdq, err = fw.HasController.CreateComponentDetectionQuery(sampleEntry.Name, testNamespace, sampleEntryGit, "", "", "", false)
+						Expect(err).NotTo(HaveOccurred())
+						break
+					}
+				}
 			})
 
 			It("creates component", func() {

--- a/tests/rhtap/types.go
+++ b/tests/rhtap/types.go
@@ -15,12 +15,17 @@ type Git struct {
 	Remotes Remotes `yaml:"remotes"`
 }
 
+type Version struct {
+	Default bool `yaml:"default"`
+	Git     Git  `yaml:"git"`
+}
+
 type SampleEntry struct {
-	Name        string `yaml:"name"`
-	DisplayName string `yaml:"displayName"`
-	Language    string `yaml:"language"`
-	ProjectType string `yaml:"projectType"`
-	Git         Git    `yaml:"git"`
+	Name        string    `yaml:"name"`
+	DisplayName string    `yaml:"displayName"`
+	Language    string    `yaml:"language"`
+	ProjectType string    `yaml:"projectType"`
+	Versions    []Version `yaml:"versions"`
 }
 
 type ExtraDevfileEntries struct {


### PR DESCRIPTION
### What does this PR do?:

After the merge of https://github.com/devfile/registry/pull/254 the `extraDevfilesEntries.yaml` now supports multiple sample versions. The `tests/rhtap/rhtap_test.go` test was using directly the `entry.Git.Remotes.Origin` and wasn't checking for existing sample versions.

As a result, this PR introduces an update to the `rhtap_test.go` where the `types.go` are updated to reflect the support of multiple sample version and upon testing to check for a default sample version instead of `entry.Git.Remotes`.

### Which issue(s) this PR fixes:

Fixes https://github.com/devfile/api/issues/1372

### PR acceptance criteria:

- [x] Contributing guide
_Have you read the [devfile registry contributing guide](https://github.com/devfile/registry/blob/main/CONTRIBUTING.md) and followed its instructions?_
- [x] Test automation
_Does this repository's tests pass with your changes?_
- [x] Documentation
_Does any documentation need to be updated with your changes?_
- [x] Check Tools Provider
_Have you tested the changes with existing tools, i.e. Odo, Che, Console? (See [devfile registry contributing guide](https://github.com/devfile/registry/blob/main/CONTRIBUTING.md) on how to test changes)_


### How to test changes / Special notes to the reviewer: