### PR TITLE
Revert updates to renovate.json

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,53 +1,47 @@
 {
-    "$schema": "https://docs.renovatebot.com/renovate-schema.json",
-    "extends": [
-      "github>platform-engineering-org/.github",
-      ":gitSignOff"
-    ],
-    "timezone": "America/Toronto",
-    "schedule": ["on the 2nd and 4th day instance on thursday after 9pm"],
-    "enabledManagers": ["regex", "github-actions"],
-    "regexManagers": [
+  "$schema": "https://docs.renovatebot.com/renovate-schema.json",
+  "extends": [
+    "config:base",
+    "helpers:pinGitHubActionDigests",
+    ":gitSignOff"
+  ],
+  "timezone": "America/Toronto",
+  "schedule": ["on the 2nd and 4th day instance on thursday after 9pm"],
+  "enabledManagers": ["regex", "github-actions"],
+  "regexManagers": [
+    {
+      "fileMatch": [
+        "devfile.*y[a]?ml$"
+      ],
+      "matchStrings": [
+        "image: (?<depName>\\S*):(?<currentValue>\\S*)"
+      ],
+      "datasourceTemplate": "docker",
+      "depNameTemplate": "{{{depName}}}"
+    }
+  ],
+  "packageRules": [
       {
-        "fileMatch": [
-          "devfile.*y[a]?ml$"
-        ],
-        "matchStrings": [
-          "image: (?<depName>\\S*):(?<currentValue>\\S*)"
-        ],
-        "datasourceTemplate": "docker",
-        "depNameTemplate": "{{{depName}}}"
+        "matchManagers": ["github-actions"],
+        "groupName": "github actions",
+        "groupSlug": "github-actions",
+        "commitMessageTopic": "{{depName}}"
       }
-    ],
-    "packageRules": [
-        {
-          "matchManagers": ["github-actions"],
-          "groupName": "github actions",
-          "groupSlug": "github-actions",
-          "commitMessageTopic": "{{depName}}",
-          "automerge": false,
-          "platformAutomerge": false
-        },
-        {
-          "description": "Disable grouping patch and digest updates",
-          "matchUpdateTypes": ["patch", "digest"],
-          "groupName": null
-        }
-    ],
-    "ignorePaths": [
-      "**/docker/**",
-      ".ci/**",
-      "tests/**",
-      "stacks/java-openliberty/**",
-      "stacks/java-openliberty-gradle/**",
-      "stacks/java-websphereliberty/**",
-      "stacks/java-websphereliberty-gradle/**",
-      "stacks/nodejs/**",
-      "stacks/go/1.0.2/**",
-      "stacks/go/1.1.0/**",
-      "stacks/go/2.0.0/**",
-      "stacks/go/2.1.0/**"
-    ],
-    "prHourlyLimit": 20,
-    "prConcurrentLimit": 5
-  }
+  ],
+  "ignorePaths": [
+    "**/docker/**",
+    ".ci/**",
+    "tests/**",
+    "stacks/java-openliberty/**",
+    "stacks/java-openliberty-gradle/**",
+    "stacks/java-websphereliberty/**",
+    "stacks/java-websphereliberty-gradle/**",
+    "stacks/nodejs/**",
+    "stacks/go/1.0.2/**",
+    "stacks/go/1.1.0/**",
+    "stacks/go/2.0.0/**",
+    "stacks/go/2.1.0/**"
+  ],
+  "prHourlyLimit": 20,
+  "prConcurrentLimit": 5
+}


### PR DESCRIPTION
### What does this PR do?:

This PR reverts all updates into the `renovate.json` file in order to prevent the bot from automerging the automatically created PRs in order to update the image tags used inside devfiles. Example PRs that have been automatically merged:

* https://github.com/devfile/registry/pull/261
* https://github.com/devfile/registry/pull/259
* https://github.com/devfile/registry/pull/260

In order to bring back the changes introduced here: https://github.com/devfile/registry/pull/240 we should confirm that the bot does not automerge the PRs.

### Which issue(s) this PR fixes:

N/A

### PR acceptance criteria:

- [ ] Contributing guide
_Have you read the [devfile registry contributing guide](https://github.com/devfile/registry/blob/main/CONTRIBUTING.md) and followed its instructions?_
- [ ] Test automation
_Does this repository's tests pass with your changes?_
- [ ] Documentation
_Does any documentation need to be updated with your changes?_
- [ ] Check Tools Provider
_Have you tested the changes with existing tools, i.e. Odo, Che, Console? (See [devfile registry contributing guide](https://github.com/devfile/registry/blob/main/CONTRIBUTING.md) on how to test changes)_


### How to test changes / Special notes to the reviewer: