### PR TITLE
Add vertx-secured-http-example in odov3 skipped starterprojects

### DIFF
--- a/tests/check_odov3.sh
+++ b/tests/check_odov3.sh
@@ -13,6 +13,7 @@ ginkgo run --procs 2 \
   --skip="stack: java-vertx version: 1.2.0 starter: vertx-crud-example-redhat" \
   --skip="stack: java-vertx version: 1.2.0 starter: vertx-crud-example" \
   --skip="stack: java-vertx version: 1.2.0 starter: vertx-http-example-redhat" \
+  --skip="stack: java-vertx version: 1.2.0 starter: vertx-secured-http-example" \
   --skip="stack: java-vertx version: 1.2.0 starter: vertx-istio-circuit-breaker-booster" \
   --skip="stack: java-vertx version: 1.2.0 starter: vertx-istio-distributed-tracing-booster" \
   --skip="stack: java-vertx version: 1.2.0 starter: vertx-istio-routing-booster" \


### PR DESCRIPTION
### What does this PR do?:

This PR adds the `vertx-secured-http-example` in the list of skipped stacks of the `test/check_odov3.sh` test, following what has been done for the rest of the `vertx` starter projects. This can help to avoid having check failures for vert.x tests because of high demand of resources.

Example failure can be found here: https://github.com/devfile/registry/actions/runs/7250922945/job/19779089833

### Which issue(s) this PR fixes:
N/A

### PR acceptance criteria:

- [x] Contributing guide
_Have you read the [devfile registry contributing guide](https://github.com/devfile/registry/blob/main/CONTRIBUTING.md) and followed its instructions?_
- [x] Test automation
_Does this repository's tests pass with your changes?_
- [x] Documentation
_Does any documentation need to be updated with your changes?_
- [x] Check Tools Provider
_Have you tested the changes with existing tools, i.e. Odo, Che, Console? (See [devfile registry contributing guide](https://github.com/devfile/registry/blob/main/CONTRIBUTING.md) on how to test changes)_


### How to test changes / Special notes to the reviewer: