### PR TITLE
Increase prConcurrentLimit to 10

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -43,5 +43,5 @@
     "stacks/go/2.1.0/**"
   ],
   "prHourlyLimit": 20,
-  "prConcurrentLimit": 5
+  "prConcurrentLimit": 10
 }


### PR DESCRIPTION
### What does this PR do?:

Simply increases the `prConcurrentLimit` from 5 to 10. This will help us update more stack image versions per run and ensure that all stacks are checked once every two weeks.

### Which issue(s) this PR fixes:
N/A

### PR acceptance criteria:

- [x] Contributing guide
_Have you read the [devfile registry contributing guide](https://github.com/devfile/registry/blob/main/CONTRIBUTING.md) and followed its instructions?_
- [x] Test automation
_Does this repository's tests pass with your changes?_
- [x] Documentation
_Does any documentation need to be updated with your changes?_
- [x] Check Tools Provider
_Have you tested the changes with existing tools, i.e. Odo, Che, Console? (See [devfile registry contributing guide](https://github.com/devfile/registry/blob/main/CONTRIBUTING.md) on how to test changes)_


### How to test changes / Special notes to the reviewer: