### PR TITLE
Exclude root devfile from renovate checks

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -31,6 +31,9 @@
   "ignorePaths": [
     "**/docker/**",
     ".devfile.yaml",
+    ".devfile.yml",
+    "devfile.yaml",
+    "devfile.yml",
     ".ci/**",
     "tests/**",
     "stacks/java-openliberty/**",

--- a/renovate.json
+++ b/renovate.json
@@ -30,6 +30,7 @@
   ],
   "ignorePaths": [
     "**/docker/**",
+    ".devfile.yaml",
     ".ci/**",
     "tests/**",
     "stacks/java-openliberty/**",


### PR DESCRIPTION
### What does this PR do?:

This PR simply removes the `.devfile.yaml` file from the renovate checks.

### Which issue(s) this PR fixes:

N/A

### PR acceptance criteria:

- [x] Contributing guide
_Have you read the [devfile registry contributing guide](https://github.com/devfile/registry/blob/main/CONTRIBUTING.md) and followed its instructions?_
- [x] Test automation
_Does this repository's tests pass with your changes?_
- [x] Documentation
_Does any documentation need to be updated with your changes?_
- [x] Check Tools Provider
_Have you tested the changes with existing tools, i.e. Odo, Che, Console? (See [devfile registry contributing guide](https://github.com/devfile/registry/blob/main/CONTRIBUTING.md) on how to test changes)_


### How to test changes / Special notes to the reviewer: