### PR TITLE
Add slack notification for validate checks run

### DIFF
--- a/.github/workflows/validate-stacks.yaml
+++ b/.github/workflows/validate-stacks.yaml
@@ -174,7 +174,7 @@ jobs:
                   "type": "section",
                   "text": {
                     "type": "mrkdwn",
-                    "text": "*Status:* :red_circle: failure\n*Severity:* medium\n*Title:* Registry's validate stacks nightly run\n*Description:* run failed for HEAD_REF ${{ github.ref }}"
+                    "text": "*Status:* :red_circle: failure\n*Severity:* medium\n*Title:* Registry's validate stacks nightly run\n*Description:* run failed for ${{ github.ref }} - ${{ github.sha }}"
                   }
                 },
                 {

--- a/.github/workflows/validate-stacks.yaml
+++ b/.github/workflows/validate-stacks.yaml
@@ -157,12 +157,12 @@ jobs:
         run: bash tests/check_odov3.sh
 
   slack_notification:
-    name: with odo v3
+    name: send slack notification
     runs-on: ubuntu-latest
     needs: [validate-devfile-schema, non-terminating, odov2, odov3]
     steps:
       - name: Send slack notification
-        if: ${{ always() && contains(needs.*.result, 'failure') }}
+        if: ${{ always() && contains(needs.*.result, 'failure') &&  github.event_name == 'schedule' }}
         uses: slackapi/slack-github-action@e28cf165c92ffef168d23c5c9000cffc8a25e117 # v1.24.0
         with:
           channel-id: ${{ secrets.SLACK_CHANNEL_ID }}

--- a/.github/workflows/validate-stacks.yaml
+++ b/.github/workflows/validate-stacks.yaml
@@ -193,5 +193,5 @@ jobs:
               ]
             }
         env:
-          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_NOTIFICATIONS_TOKEN }}
+          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
           SLACK_WEBHOOK_TYPE: INCOMING_WEBHOOK

--- a/.github/workflows/validate-stacks.yaml
+++ b/.github/workflows/validate-stacks.yaml
@@ -155,3 +155,43 @@ jobs:
 
       - name: Check the devfile stacks with odo v3
         run: bash tests/check_odov3.sh
+
+  slack_notification:
+    name: with odo v3
+    runs-on: ubuntu-latest
+    needs: [validate-devfile-schema, non-terminating, odov2, odov3]
+    steps:
+      - name: Send slack notification
+        if: ${{ always() && contains(needs.*.result, 'failure') }}
+        uses: slackapi/slack-github-action@e28cf165c92ffef168d23c5c9000cffc8a25e117 # v1.24.0
+        with:
+          channel-id: ${{ secrets.SLACK_CHANNEL_ID }}
+          payload: |
+            {
+              "text": "GitHub Action failed",
+              "blocks": [
+                {
+                  "type": "section",
+                  "text": {
+                    "type": "mrkdwn",
+                    "text": "*Status:* :red_circle: failure\n*Severity:* medium\n*Title:* Registry's validate stacks nightly run\n*Description:* run failed for HEAD_REF ${{ github.head_ref }}"
+                  }
+                },
+                {
+                  "type": "actions",
+                  "elements": [
+                    {
+                      "type": "button",
+                      "text": {
+                        "type": "plain_text",
+                        "text": ":github: Failed action"
+                      },
+                      "url": "${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
+                    }
+                  ]
+                }
+              ]
+            }
+        env:
+          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_NOTIFICATIONS_TOKEN }}
+          SLACK_WEBHOOK_TYPE: INCOMING_WEBHOOK

--- a/.github/workflows/validate-stacks.yaml
+++ b/.github/workflows/validate-stacks.yaml
@@ -174,7 +174,7 @@ jobs:
                   "type": "section",
                   "text": {
                     "type": "mrkdwn",
-                    "text": "*Status:* :red_circle: failure\n*Severity:* medium\n*Title:* Registry's validate stacks nightly run\n*Description:* run failed for ${{ github.ref }} - ${{ github.sha }}"
+                    "text": "*Status:* :red_circle: failure\n*Severity:* medium\n*Title:* Registry's validate stacks nightly run\n*Description:* run failed for `${{ github.ref }}` - `${{ github.sha }}`"
                   }
                 },
                 {

--- a/.github/workflows/validate-stacks.yaml
+++ b/.github/workflows/validate-stacks.yaml
@@ -159,10 +159,10 @@ jobs:
   slack_notification:
     name: send slack notification
     runs-on: ubuntu-latest
+    if: ${{ always() && contains(join(needs.*.result, ','), 'failure') &&  github.event_name == 'schedule' }}
     needs: [validate-devfile-schema, non-terminating, odov2, odov3]
     steps:
       - name: Send slack notification
-        if: ${{ always() && contains(needs.*.result, 'failure') &&  github.event_name == 'schedule' }}
         uses: slackapi/slack-github-action@e28cf165c92ffef168d23c5c9000cffc8a25e117 # v1.24.0
         with:
           channel-id: ${{ secrets.SLACK_CHANNEL_ID }}
@@ -174,7 +174,7 @@ jobs:
                   "type": "section",
                   "text": {
                     "type": "mrkdwn",
-                    "text": "*Status:* :red_circle: failure\n*Severity:* medium\n*Title:* Registry's validate stacks nightly run\n*Description:* run failed for HEAD_REF ${{ github.head_ref }}"
+                    "text": "*Status:* :red_circle: failure\n*Severity:* medium\n*Title:* Registry's validate stacks nightly run\n*Description:* run failed for HEAD_REF ${{ github.ref }}"
                   }
                 },
                 {


### PR DESCRIPTION
### What does this PR do?:

This PR adds a slack notification for the `validate-stacks` nightly run. More detailed if a run fails in any of the jobs github action will send a slack message to the referenced `SLACK_CHANNEL_ID`.

The message format has been defined in the related issue.

### Which issue(s) this PR fixes:

Fixes https://github.com/devfile/api/issues/1061

### PR acceptance criteria:

- [ ] Contributing guide
_Have you read the [devfile registry contributing guide](https://github.com/devfile/registry/blob/main/CONTRIBUTING.md) and followed its instructions?_
- [ ] Test automation
_Does this repository's tests pass with your changes?_
- [ ] Documentation
_Does any documentation need to be updated with your changes?_
- [ ] Check Tools Provider
_Have you tested the changes with existing tools, i.e. Odo, Che, Console? (See [devfile registry contributing guide](https://github.com/devfile/registry/blob/main/CONTRIBUTING.md) on how to test changes)_


### How to test changes / Special notes to the reviewer: