### PR TITLE
Add vertx-configmap-example to odo3 check's skipped starterprojects

### DIFF
--- a/tests/check_odov3.sh
+++ b/tests/check_odov3.sh
@@ -12,6 +12,7 @@ ginkgo run --procs 2 \
   --skip="stack: java-vertx version: 1.2.0 starter: vertx-circuit-breaker-example" \
   --skip="stack: java-vertx version: 1.2.0 starter: vertx-crud-example-redhat" \
   --skip="stack: java-vertx version: 1.2.0 starter: vertx-crud-example" \
+  --skip="stack: java-vertx version: 1.2.0 starter: vertx-configmap-example" \
   --skip="stack: java-vertx version: 1.2.0 starter: vertx-http-example-redhat" \
   --skip="stack: java-vertx version: 1.2.0 starter: vertx-secured-http-example" \
   --skip="stack: java-vertx version: 1.2.0 starter: vertx-istio-circuit-breaker-booster" \


### PR DESCRIPTION
### What does this PR do?:
Simply adds another `vert.x` starterproject as a skipped one following the same reasoning with https://github.com/devfile/registry/pull/264 and all other vert.x examples skipped in the past.

### Which issue(s) this PR fixes:
N/A

### PR acceptance criteria:

- [ ] Contributing guide
_Have you read the [devfile registry contributing guide](https://github.com/devfile/registry/blob/main/CONTRIBUTING.md) and followed its instructions?_
- [ ] Test automation
_Does this repository's tests pass with your changes?_
- [ ] Documentation
_Does any documentation need to be updated with your changes?_
- [ ] Check Tools Provider
_Have you tested the changes with existing tools, i.e. Odo, Che, Console? (See [devfile registry contributing guide](https://github.com/devfile/registry/blob/main/CONTRIBUTING.md) on how to test changes)_


### How to test changes / Special notes to the reviewer: