### PR TITLE
Fix devfile udi stack icon

### DIFF
--- a/stacks/udi/devfile.yaml
+++ b/stacks/udi/devfile.yaml
@@ -3,7 +3,7 @@ metadata:
   name: udi
   displayName: Universal Developer Image
   description: Universal Developer Image provides various programming languages tools and runtimes for instant coding
-  icon: https://landscape.cncf.io/logos/devfile.svg
+  icon: https://raw.githubusercontent.com/devfile/devfile-web/main/apps/landing-page/public/pwa-192x192.png
   tags:
     - Java
     - Maven


### PR DESCRIPTION
### What does this PR do?:
All recent [PRs](https://github.com/devfile/registry/pulls) for registry have failed for the following trace:

```
Error: failed to generate index struct: udi index component is not valid:
Devfile udi has broken or not existing icon
```

This PR simply adds the raw devfile icon image found inside the [devfile-web repo](https://raw.githubusercontent.com/devfile/devfile-web/main/apps/landing-page/public/pwa-192x192.png).
 
### Which issue(s) this PR fixes:
N/A

### PR acceptance criteria:

- [ ] Contributing guide
_Have you read the [devfile registry contributing guide](https://github.com/devfile/registry/blob/main/CONTRIBUTING.md) and followed its instructions?_
- [ ] Test automation
_Does this repository's tests pass with your changes?_
- [ ] Documentation
_Does any documentation need to be updated with your changes?_
- [ ] Check Tools Provider
_Have you tested the changes with existing tools, i.e. Odo, Che, Console? (See [devfile registry contributing guide](https://github.com/devfile/registry/blob/main/CONTRIBUTING.md) on how to test changes)_


### How to test changes / Special notes to the reviewer: