### PR TITLE
chore: use 'https' protocol for .net 6.0 devfile. Update schema to 2.2.0

### DIFF
--- a/stacks/dotnet60/devfile.yaml
+++ b/stacks/dotnet60/devfile.yaml
@@ -1,4 +1,4 @@
-schemaVersion: 2.1.0
+schemaVersion: 2.2.0
 metadata:
   name: dotnet60
   displayName: .NET 6.0
@@ -9,7 +9,7 @@ metadata:
     - .NET 6.0
   projectType: dotnet
   language: .NET
-  version: 1.0.2
+  version: 1.0.3
 starterProjects:
   - name: dotnet60-example
     git:
@@ -35,7 +35,8 @@ components:
         - name: ASPNETCORE_URLS
           value: http://*:8080
       endpoints:
-        - name: http-dotnet60
+        - name: https-dotnet60
+          protocol: https
           targetPort: 8080
 commands:
   - id: build


### PR DESCRIPTION
### What does this PR do?:
- update schema to the 2.2.0 (latest 2.2.2 is not yet supported - https://github.com/devfile/api/issues/1454)
- use 'https' protocol for .net 6.0 devfile

### Which issue(s) this PR fixes:
N/A

### PR acceptance criteria:

- [ ] Contributing guide
_Have you read the [devfile registry contributing guide](https://github.com/devfile/registry/blob/main/CONTRIBUTING.md) and followed its instructions?_
- [ ] Test automation
_Does this repository's tests pass with your changes?_
- [ ] Documentation
_Does any documentation need to be updated with your changes?_
- [ ] Check Tools Provider
_Have you tested the changes with existing tools, i.e. Odo, Che, Console? (See [devfile registry contributing guide](https://github.com/devfile/registry/blob/main/CONTRIBUTING.md) on how to test changes)_


### How to test changes / Special notes to the reviewer:

try it out on Developer Sandbox - https://workspaces.openshift.com/#https://raw.githubusercontent.com/devfile/registry/1f99545009bad5ab1f3231c66bcd6bf29d583573/stacks/dotnet60/devfile.yaml