### PR TITLE
WIP: Fix validate stacks nightly run

### DIFF
--- a/tests/check_odov2.sh
+++ b/tests/check_odov2.sh
@@ -206,7 +206,7 @@ for stack in $STACKS; do
 
   # Skipping the java-wildfly-bootable-jar stack right now since it's broken.
   # TODO: Uncomment once fixed.
-  if [ $stack != "java-wildfly-bootable-jar" ]; then
+  if [ $stack != "java-wildfly-bootable-jar" ] && [ $stack != "java-wildfly/1.1.0" ]; then
     test "$devfile_name" "$devfile_version" "$devfile_path"
   fi
 done

--- a/tests/check_odov3.sh
+++ b/tests/check_odov3.sh
@@ -40,5 +40,5 @@ ginkgo run --procs 2 \
   --skip="stack: java-openliberty" \
   --skip="stack: java-websphereliberty" \
   --slow-spec-threshold 120s \
-  --timeout 2h \
+  --timeout 3h \
   tests/odov3 -- -stacksPath "$(pwd)"/stacks -stackDirs "$stackDirs"


### PR DESCRIPTION
### What does this PR do?:
This PR introduces two fixes for the `validate-stacks.yaml` nightly run. At the moment the run fails every time due to two different reasons:

1. The `check_odov2.sh` checks fails to deploy the `java-wildfly/1.1.0` stack version as it needs a lot of resources.
2. The `check_odov3.sh` reaches the `ginkgo` timeout of `2h`.

More info can be found here: https://github.com/devfile/registry/actions/runs/7968684092

In an attempt to fix this workflow this PR updates:
* Skips the `java-wildfly/1.1.0` for `check_odov2.sh` check. An alternative tried was to give more resources to the `minikube` instance (4 cpus & 6GB memory) but it was still failing. This alternative solution follows the same logic with https://github.com/openshift/release/pull/11695/files.
* Increases the `ginkgo` timeout from `2h` to `3h` for `check_odov3.sh`.

### Which issue(s) this PR fixes:
N/A

### PR acceptance criteria:

- [ ] Contributing guide
_Have you read the [devfile registry contributing guide](https://github.com/devfile/registry/blob/main/CONTRIBUTING.md) and followed its instructions?_
- [ ] Test automation
_Does this repository's tests pass with your changes?_
- [ ] Documentation
_Does any documentation need to be updated with your changes?_
- [ ] Check Tools Provider
_Have you tested the changes with existing tools, i.e. Odo, Che, Console? (See [devfile registry contributing guide](https://github.com/devfile/registry/blob/main/CONTRIBUTING.md) on how to test changes)_


### How to test changes / Special notes to the reviewer: