### PR TITLE
Skip java-wildfly 1.1.0 for check_odov2

### DIFF
--- a/tests/check_odov2.sh
+++ b/tests/check_odov2.sh
@@ -206,7 +206,7 @@ for stack in $STACKS; do
 
   # Skipping the java-wildfly-bootable-jar stack right now since it's broken.
   # TODO: Uncomment once fixed.
-  if [ $stack != "java-wildfly-bootable-jar" ]; then
+  if [ $stack != "java-wildfly-bootable-jar" ] && [ $stack != "java-wildfly/1.1.0" ]; then
     test "$devfile_name" "$devfile_version" "$devfile_path"
   fi
 done


### PR DESCRIPTION
### What does this PR do?:

The `java-wildfly/1.1.0` stack is failing for the scheduled check of validating stacks. The failure is related to the amount of resources which are required for this deployment and as a result we are not able to apply the `check_odov2` check for this case.

In order to avoid having a failure to every run, we temporarily exclude the `java-wildfly/1.1.0` stack from the check.

### Which issue(s) this PR fixes:
N/A

### PR acceptance criteria:

- [ ] Contributing guide
_Have you read the [devfile registry contributing guide](https://github.com/devfile/registry/blob/main/CONTRIBUTING.md) and followed its instructions?_
- [ ] Test automation
_Does this repository's tests pass with your changes?_
- [ ] Documentation
_Does any documentation need to be updated with your changes?_
- [ ] Check Tools Provider
_Have you tested the changes with existing tools, i.e. Odo, Che, Console? (See [devfile registry contributing guide](https://github.com/devfile/registry/blob/main/CONTRIBUTING.md) on how to test changes)_


### How to test changes / Special notes to the reviewer: