### PR TITLE
Add support for arm64 users to build scripts

### DIFF
--- a/.ci/build_and_deploy.sh
+++ b/.ci/build_and_deploy.sh
@@ -20,6 +20,8 @@ INDEX_IMAGE="${INDEX_IMAGE:-quay.io/app-sre/devfile-index}"
 VIEWER_IMAGE="${VIEWER_IMAGE:-quay.io/app-sre/registry-viewer}"
 IMAGE_TAG="${IMAGE_TAG:-${GIT_REV}}"
 USE_PODMAN=${USE_PODMAN:-false}
+# PLATFORM_EV is required by the devfile-web/scripts/build_viewer.sh script
+PLATFORM_EV=${PLATFORM_EV:-"linux/amd64"}
 
 # Ensure container engine is set properly for devfile-web scripts
 if [[ ${USE_PODMAN} == true ]]; then
@@ -37,6 +39,8 @@ then
 fi
 git clone https://github.com/devfile/devfile-web.git $ABSOLUTE_PATH/devfile-web
 
+# export PLATFORM_EV so build_viewer.sh does not fail for MacOS users
+export PLATFORM_EV
 # Build registry-viewer
 bash $ABSOLUTE_PATH/devfile-web/scripts/build_viewer.sh
 

--- a/README.md
+++ b/README.md
@@ -33,6 +33,8 @@ To build this devfile registry into a container image run `bash .ci/build.sh`. A
 
 From there, push the container image to a container registry of your choice and deploy using a [devfile adopted devtool](https://devfile.io/docs/2.2.0/developing-with-devfiles#tools-that-provide-devfile-support) or one of the methods outlined [here](https://github.com/devfile/registry-support#deploy).
 
+If you are trying to run `bash .ci/build_and_deploy.sh` and are experiencing errors while on a Mac with an apple silicon chip, you should first run `export PLATFORM_EV=linux/arm64` to properly set the container config. By default the containers will be built for `linux/amd64`.
+
 ## Devfile Deployments
 
 ### Prerequisites

--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ To build this devfile registry into a container image run `bash .ci/build.sh`. A
 
 From there, push the container image to a container registry of your choice and deploy using a [devfile adopted devtool](https://devfile.io/docs/2.2.0/developing-with-devfiles#tools-that-provide-devfile-support) or one of the methods outlined [here](https://github.com/devfile/registry-support#deploy).
 
-If you are trying to run `bash .ci/build_and_deploy.sh` and are experiencing errors while on a Mac with an apple silicon chip, you should first run `export PLATFORM_EV=linux/arm64` to properly set the container config. By default the containers will be built for `linux/amd64`.
+If you are trying to run `bash .ci/build_and_deploy.sh` and are experiencing errors while using MacOS with an apple silicon chip, you should first run `export PLATFORM_EV=linux/arm64` to properly set the container config. By default the containers will be built for `linux/amd64`.
 
 ## Devfile Deployments
 


### PR DESCRIPTION
### What does this PR do?:
This PR enables the use of the `PLATFORM_EV` variable for users running `build_and_deploy.sh`. Due to a change made [here](https://github.com/devfile/devfile-web/commit/163464ed66bbf9354a1c683571360980cab4a3b9) on `devfile-web`, the build script requires the setting of `PLATFORM_EV` to run properly for users on arm64 architecture. In the devfile registry `build_and_deploy.sh` script it clones and runs build scripts from `devfile-web`. These would fail without this change.

### Which issue(s) this PR fixes:
fixes https://github.com/devfile/api/issues/1366

### PR acceptance criteria:

- [ ] Contributing guide
_Have you read the [devfile registry contributing guide](https://github.com/devfile/registry/blob/main/CONTRIBUTING.md) and followed its instructions?_
- [ ] Test automation
_Does this repository's tests pass with your changes?_
- [ ] Documentation
_Does any documentation need to be updated with your changes?_
- [ ] Check Tools Provider
_Have you tested the changes with existing tools, i.e. Odo, Che, Console? (See [devfile registry contributing guide](https://github.com/devfile/registry/blob/main/CONTRIBUTING.md) on how to test changes)_


### How to test changes / Special notes to the reviewer:
Running `bash ./.ci/build_and_deploy.sh` successfully runs and builds the images.