### PR TITLE
[DevTools] Add codeowners to devfile owned stacks

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,11 @@
+# Devfile owned stacks
+/stacks/nodejs-angular/ @devfile/devfile-services-team
+/stacks/python-django/ @devfile/devfile-services-team
+/stacks/go/ @devfile/devfile-services-team
+/stacks/php-laravel/ @devfile/devfile-services-team
+/stacks/nodejs-nextjs/ @devfile/devfile-services-team
+/stacks/nodejs-nuxtjs/ @devfile/devfile-services-team
+/stacks/python/ @devfile/devfile-services-team
+/stacks/nodejs-react/ @devfile/devfile-services-team
+/stacks/nodejs-svelte/ @devfile/devfile-services-team
+/stacks/nodejs-vue/ @devfile/devfile-services-team


### PR DESCRIPTION
### What does this PR do?:
Adds `CODEOWNERS` file referencing [Devfile Services Team](https://github.com/orgs/devfile/teams/devfile-services-team) to their owned community devfile registry stacks.

### Which issue(s) this PR fixes:
fixes devfile/api#1458

### PR acceptance criteria:

- [ ] Contributing guide
_Have you read the [devfile registry contributing guide](https://github.com/devfile/registry/blob/main/CONTRIBUTING.md) and followed its instructions?_
- [ ] Test automation
_Does this repository's tests pass with your changes?_
- [ ] Documentation
_Does any documentation need to be updated with your changes?_
- [ ] Check Tools Provider
_Have you tested the changes with existing tools, i.e. Odo, Che, Console? (See [devfile registry contributing guide](https://github.com/devfile/registry/blob/main/CONTRIBUTING.md) on how to test changes)_


### How to test changes / Special notes to the reviewer: