### PR TITLE
chore: use 'https' protocol for .net 5.0 devfile. Update schema to 2.2.0

### DIFF
--- a/stacks/dotnet50/devfile.yaml
+++ b/stacks/dotnet50/devfile.yaml
@@ -1,4 +1,4 @@
-schemaVersion: 2.1.0
+schemaVersion: 2.2.0
 metadata:
   name: dotnet50
   displayName: .NET 5.0
@@ -9,7 +9,7 @@ metadata:
     - .NET 5.0
   projectType: dotnet
   language: .NET
-  version: 1.0.3
+  version: 1.0.4
 starterProjects:
   - name: dotnet50-example
     git:
@@ -35,7 +35,8 @@ components:
         - name: ASPNETCORE_URLS
           value: http://*:8080
       endpoints:
-        - name: http-dotnet50
+        - name: https-dotnet50
+          protocol: https
           targetPort: 8080
 commands:
   - id: build


### PR DESCRIPTION
### What does this PR do?:

use 'https' protocol for .net 5.0 devfile. Update schema to 2.2.0

similar PR for .net 6.0 - https://github.com/devfile/registry/pull/298

### Which issue(s) this PR fixes:
_Link to github issue(s)_

### PR acceptance criteria:

- [ ] Contributing guide
_Have you read the [devfile registry contributing guide](https://github.com/devfile/registry/blob/main/CONTRIBUTING.md) and followed its instructions?_
- [ ] Test automation
_Does this repository's tests pass with your changes?_
- [ ] Documentation
_Does any documentation need to be updated with your changes?_
- [ ] Check Tools Provider
_Have you tested the changes with existing tools, i.e. Odo, Che, Console? (See [devfile registry contributing guide](https://github.com/devfile/registry/blob/main/CONTRIBUTING.md) on how to test changes)_


### How to test changes / Special notes to the reviewer:

try it out on Developer Sandbox - https://workspaces.openshift.com/#https://raw.githubusercontent.com/devfile/registry/dff9ad0e8c2ce5cc6de8e5d05b82e80bb1155bc0/stacks/dotnet50/devfile.yaml