### PR TITLE
Freeze `devfile-index-base` at `ffc3a09`

### DIFF
--- a/.ci/Dockerfile
+++ b/.ci/Dockerfile
@@ -31,6 +31,8 @@ RUN bash /registry-support/build-tools/build.sh /registry /build
 # Set user as non-root
 USER 1001
 
-FROM quay.io/devfile/devfile-index-base:next
+# Freeze at devfile/registry-support commit ffc3a09 until Go 1.19 is supported, 
+# see https://github.com/devfile/api/issues/1473
+FROM quay.io/devfile/devfile-index-base:ffc3a09964b840b3d421dcf5d8d2afbf69322f64
 
 COPY --from=builder /build /registry

--- a/.ci/Dockerfile.offline
+++ b/.ci/Dockerfile.offline
@@ -40,7 +40,9 @@ RUN bash /registry-support/build-tools/build.sh /registry /build
 # Extract archived resources
 RUN bash /registry-support/build-tools/extract_resources.sh
 
-FROM quay.io/devfile/devfile-index-base:next
+# Freeze at devfile/registry-support commit ffc3a09 until Go 1.19 is supported, 
+# see https://github.com/devfile/api/issues/1473
+FROM quay.io/devfile/devfile-index-base:ffc3a09964b840b3d421dcf5d8d2afbf69322f64
 
 # Set user as non-root
 USER 1001


### PR DESCRIPTION
### What does this PR do?:
_Summarize the changes. Are any stacks or samples added or updated?_

Freezes `devfile-index-base` at https://github.com/devfile/registry-support/commit/ffc3a09964b840b3d421dcf5d8d2afbf69322f64 until devfile/api#1473 is resolved to support Go 1.19 for the community registry.

This is needed to merge https://github.com/devfile/registry-support/pull/212 successfully.

**Important: Updates to the [registry viewer](https://github.com/devfile/devfile-web) or the stack/sample content will still apply to deployments.**

### Which issue(s) this PR fixes:
_Link to github issue(s)_

https://github.com/devfile/api/issues/1469

### PR acceptance criteria:

- [ ] Contributing guide
_Have you read the [devfile registry contributing guide](https://github.com/devfile/registry/blob/main/CONTRIBUTING.md) and followed its instructions?_
- [x] Test automation
_Does this repository's tests pass with your changes?_
- [ ] Documentation
_Does any documentation need to be updated with your changes?_
- [ ] Check Tools Provider
_Have you tested the changes with existing tools, i.e. Odo, Che, Console? (See [devfile registry contributing guide](https://github.com/devfile/registry/blob/main/CONTRIBUTING.md) on how to test changes)_


### How to test changes / Special notes to the reviewer: