### PR TITLE
Freeze index/generator at `v1.1.0`

### DIFF
--- a/.ci/Dockerfile
+++ b/.ci/Dockerfile
@@ -23,7 +23,9 @@ RUN curl -sL -O https://github.com/mikefarah/yq/releases/download/v4.9.5/yq_linu
 COPY . /registry
 
 # Download the registry build tools
-RUN git clone https://github.com/devfile/registry-support.git /registry-support
+# Freeze index/generator version at v1.1.0 until Go 1.19 is supported, 
+# see https://github.com/devfile/api/issues/1473
+RUN git clone https://github.com/devfile/registry-support.git -b v1.1.0 /registry-support
 
 # Run the registry build tools
 RUN bash /registry-support/build-tools/build.sh /registry /build

--- a/.ci/Dockerfile.offline
+++ b/.ci/Dockerfile.offline
@@ -23,7 +23,9 @@ RUN curl -sL -O https://github.com/mikefarah/yq/releases/download/v4.9.5/yq_linu
 COPY . /registry
 
 # Download the registry build tools
-RUN git clone https://github.com/devfile/registry-support.git /registry-support
+# Freeze index/generator version at v1.1.0 until Go 1.19 is supported, 
+# see https://github.com/devfile/api/issues/1473
+RUN git clone https://github.com/devfile/registry-support.git -b v1.1.0 /registry-support
 
 # Download all the offline parent devfiles
 RUN bash /registry-support/build-tools/dl_parent_devfiles.sh


### PR DESCRIPTION
### What does this PR do?:
_Summarize the changes. Are any stacks or samples added or updated?_

Continuing from https://github.com/devfile/registry/pull/316, index/generator also needs to be frozen at an earlier state (such as `v1.1.0`) to fix failures due to use of Go 1.19 since https://github.com/devfile/registry-support/commit/3325cfe7a14ca95e245f4426c6731ce5667d2ed8. This fixed use of `v1.1.0` can be lifted once https://github.com/devfile/api/issues/1473 is resolved.

### Which issue(s) this PR fixes:
_Link to github issue(s)_

https://github.com/devfile/api/issues/1469

### PR acceptance criteria:

- [ ] Contributing guide
_Have you read the [devfile registry contributing guide](https://github.com/devfile/registry/blob/main/CONTRIBUTING.md) and followed its instructions?_
- [ ] Test automation
_Does this repository's tests pass with your changes?_
- [ ] Documentation
_Does any documentation need to be updated with your changes?_
- [ ] Check Tools Provider
_Have you tested the changes with existing tools, i.e. Odo, Che, Console? (See [devfile registry contributing guide](https://github.com/devfile/registry/blob/main/CONTRIBUTING.md) on how to test changes)_


### How to test changes / Special notes to the reviewer: