### PR TITLE
add deprecation to nodejs 16

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -51,7 +51,7 @@
     "stacks/nodejs-nuxtjs/1.0.3/**",
     "stacks/nodejs-react/2.0.2/**",
     "stacks/nodejs-svelte/1.0.3/**",
-    "stacks/nodejs-vue/1.0.3/**"
+    "stacks/nodejs-vue/1.0.2/**"
   ],
   "prHourlyLimit": 20,
   "prConcurrentLimit": 10

--- a/renovate.json
+++ b/renovate.json
@@ -44,7 +44,14 @@
     "stacks/go/1.0.2/**",
     "stacks/go/1.1.0/**",
     "stacks/go/2.0.0/**",
-    "stacks/go/2.1.0/**"
+    "stacks/go/2.1.0/**",
+    "stacks/nodejs/2.1.1/**",
+    "stacks/nodejs-angular/2.0.2/**",
+    "stacks/nodejs-nextjs/1.0.3/**",
+    "stacks/nodejs-nuxtjs/1.0.3/**",
+    "stacks/nodejs-react/2.0.2/**",
+    "stacks/nodejs-svelte/1.0.3/**",
+    "stacks/nodejs-vue/1.0.3/**"
   ],
   "prHourlyLimit": 20,
   "prConcurrentLimit": 10

--- a/stacks/nodejs-angular/2.0.2/devfile.yaml
+++ b/stacks/nodejs-angular/2.0.2/devfile.yaml
@@ -10,6 +10,7 @@ metadata:
   tags:
     - Node.js
     - Angular
+    - Deprecated
   projectType: Angular
   language: TypeScript
   provider: Red Hat

--- a/stacks/nodejs-angular/stack.yaml
+++ b/stacks/nodejs-angular/stack.yaml
@@ -8,6 +8,6 @@ displayName: Angular
 icon: https://raw.githubusercontent.com/devfile-samples/devfile-stack-icons/main/angular.svg
 versions:
   - version: 2.0.2
-    default: true # should have one and only one default version
   - version: 2.1.0
+    default: true # should have one and only one default version
   - version: 2.2.0

--- a/stacks/nodejs-nextjs/1.0.3/devfile.yaml
+++ b/stacks/nodejs-nextjs/1.0.3/devfile.yaml
@@ -9,6 +9,7 @@ metadata:
   tags:
     - Node.js
     - Next.js
+    - Deprecated
   projectType: Next.js
   language: TypeScript
   provider: Red Hat

--- a/stacks/nodejs-nextjs/stack.yaml
+++ b/stacks/nodejs-nextjs/stack.yaml
@@ -7,6 +7,6 @@ displayName: Next.js
 icon: https://raw.githubusercontent.com/devfile-samples/devfile-stack-icons/main/next-js.svg
 versions:
   - version: 1.0.3
-    default: true # should have one and only one default version
   - version: 1.1.0
+    default: true # should have one and only one default version
   - version: 1.2.0

--- a/stacks/nodejs-nuxtjs/1.0.3/devfile.yaml
+++ b/stacks/nodejs-nuxtjs/1.0.3/devfile.yaml
@@ -8,6 +8,7 @@ metadata:
   tags:
     - Node.js
     - Nuxt.js
+    - Deprecated
   projectType: Nuxt.js
   language: TypeScript
   provider: Red Hat

--- a/stacks/nodejs-nuxtjs/stack.yaml
+++ b/stacks/nodejs-nuxtjs/stack.yaml
@@ -6,6 +6,6 @@ displayName: Nuxt.js
 icon: https://raw.githubusercontent.com/devfile-samples/devfile-stack-icons/main/nuxt-js.svg
 versions:
   - version: 1.0.3
-    default: true # should have one and only one default version
   - version: 1.1.0
+    default: true # should have one and only one default version
   - version: 1.2.0

--- a/stacks/nodejs-react/2.0.2/devfile.yaml
+++ b/stacks/nodejs-react/2.0.2/devfile.yaml
@@ -8,6 +8,7 @@ metadata:
   tags:
     - Node.js
     - React
+    - Deprecated
   projectType: React
   language: TypeScript
   provider: Red Hat

--- a/stacks/nodejs-react/stack.yaml
+++ b/stacks/nodejs-react/stack.yaml
@@ -6,6 +6,6 @@ displayName: React
 icon: https://raw.githubusercontent.com/devfile-samples/devfile-stack-icons/main/react.svg
 versions:
   - version: 2.0.2
-    default: true # should have one and only one default version
   - version: 2.1.0
+    default: true # should have one and only one default version
   - version: 2.2.0

--- a/stacks/nodejs-svelte/1.0.3/devfile.yaml
+++ b/stacks/nodejs-svelte/1.0.3/devfile.yaml
@@ -8,6 +8,7 @@ metadata:
   tags:
     - Node.js
     - Svelte
+    - Deprecated
   projectType: Svelte
   language: TypeScript
   provider: Red Hat

--- a/stacks/nodejs-svelte/stack.yaml
+++ b/stacks/nodejs-svelte/stack.yaml
@@ -7,7 +7,6 @@ icon: https://raw.githubusercontent.com/devfile-samples/devfile-stack-icons/main
 versions:
   - version: 1.0.3
   - version: 1.1.0
-    default: true # should have one and only one default version
   - version: 1.2.0
   - version: 1.2.1
     default: true # should have one and only one default version

--- a/stacks/nodejs-svelte/stack.yaml
+++ b/stacks/nodejs-svelte/stack.yaml
@@ -7,6 +7,7 @@ icon: https://raw.githubusercontent.com/devfile-samples/devfile-stack-icons/main
 versions:
   - version: 1.0.3
   - version: 1.1.0
+    default: true # should have one and only one default version
   - version: 1.2.0
   - version: 1.2.1
     default: true # should have one and only one default version

--- a/stacks/nodejs-vue/1.0.2/devfile.yaml
+++ b/stacks/nodejs-vue/1.0.2/devfile.yaml
@@ -8,6 +8,7 @@ metadata:
   tags:
     - Node.js
     - Vue
+    - Deprecated
   projectType: Vue
   language: TypeScript
   provider: Red Hat

--- a/stacks/nodejs-vue/stack.yaml
+++ b/stacks/nodejs-vue/stack.yaml
@@ -6,6 +6,6 @@ displayName: Vue
 icon: https://raw.githubusercontent.com/devfile-samples/devfile-stack-icons/main/vue.svg
 versions:
   - version: 1.0.2
-    default: true # should have one and only one default version
   - version: 1.1.0
+    default: true # should have one and only one default version
   - version: 1.2.0

--- a/stacks/nodejs/2.1.1/devfile.yaml
+++ b/stacks/nodejs/2.1.1/devfile.yaml
@@ -8,6 +8,7 @@ metadata:
     - Node.js
     - Express
     - ubi8
+    - Deprecated
   projectType: Node.js
   language: JavaScript
   version: 2.1.1

--- a/stacks/nodejs/stack.yaml
+++ b/stacks/nodejs/stack.yaml
@@ -4,5 +4,5 @@ displayName: Node.js Runtime
 icon: https://raw.githubusercontent.com/devfile-samples/devfile-stack-icons/main/node-js.svg
 versions:
   - version: 2.1.1
-    default: true # should have one and only one default version
   - version: 2.2.0
+    default: true # should have one and only one default version


### PR DESCRIPTION
### What does this PR do?:
_Summarize the changes. Are any stacks or samples added or updated?_

This PR adds the `Deprecated` tag to stacks with the `Nodejs 16` image. It also adds these deprecated stacks to the `renovate.json` exclusion list and bumps the default version for all changed stacks up by 1 so the default version is not a deprecated stack.

### Which issue(s) this PR fixes:
_Link to github issue(s)_
fixes https://github.com/devfile/api/issues/1364

### PR acceptance criteria:

- [ ] Contributing guide
_Have you read the [devfile registry contributing guide](https://github.com/devfile/registry/blob/main/CONTRIBUTING.md) and followed its instructions?_
- [ ] Test automation
_Does this repository's tests pass with your changes?_
- [ ] Documentation
_Does any documentation need to be updated with your changes?_
- [ ] Check Tools Provider
_Have you tested the changes with existing tools, i.e. Odo, Che, Console? (See [devfile registry contributing guide](https://github.com/devfile/registry/blob/main/CONTRIBUTING.md) on how to test changes)_


### How to test changes / Special notes to the reviewer:

