### PR TITLE
Replace nodejs icon with devfile-stack-icons link

### DIFF
--- a/extraDevfileEntries.yaml
+++ b/extraDevfileEntries.yaml
@@ -3,7 +3,7 @@ samples:
   - name: nodejs-basic
     displayName: Basic Node.js
     description: Node.js 16 application using Express 4.18.x
-    icon: https://nodejs.org/static/images/logos/nodejs-new-pantone-black.svg
+    icon: https://raw.githubusercontent.com/devfile-samples/devfile-stack-icons/main/node-js.svg
     tags:
       - Node.js
       - Express

--- a/stacks/nodejs/2.1.1/devfile.yaml
+++ b/stacks/nodejs/2.1.1/devfile.yaml
@@ -3,7 +3,7 @@ metadata:
   name: nodejs
   displayName: Node.js Runtime
   description: Node.js 16 application
-  icon: https://nodejs.org/static/images/logos/nodejs-new-pantone-black.svg
+  icon: https://raw.githubusercontent.com/devfile-samples/devfile-stack-icons/main/node-js.svg
   tags:
     - Node.js
     - Express

--- a/stacks/nodejs/2.2.0/devfile.yaml
+++ b/stacks/nodejs/2.2.0/devfile.yaml
@@ -3,7 +3,7 @@ metadata:
   name: nodejs
   displayName: Node.js Runtime
   description: Node.js 18 application
-  icon: https://nodejs.org/static/images/logos/nodejs-new-pantone-black.svg
+  icon: https://raw.githubusercontent.com/devfile-samples/devfile-stack-icons/main/node-js.svg
   tags:
     - Node.js
     - Express

--- a/stacks/nodejs/stack.yaml
+++ b/stacks/nodejs/stack.yaml
@@ -1,7 +1,7 @@
 name: nodejs
 description: 'Node.js application'
 displayName: Node.js Runtime
-icon: https://nodejs.org/static/images/logos/nodejs-new-pantone-black.svg
+icon: https://raw.githubusercontent.com/devfile-samples/devfile-stack-icons/main/node-js.svg
 versions:
   - version: 2.1.1
     default: true # should have one and only one default version


### PR DESCRIPTION
### What does this PR do?:

Replaces the broken icon for `nodejs` stack with the one added in the `devfile-stack-icons` repo. 

### Which issue(s) this PR fixes:

Fixes https://github.com/devfile/api/issues/1484

### PR acceptance criteria:

- [ ] Contributing guide
_Have you read the [devfile registry contributing guide](https://github.com/devfile/registry/blob/main/CONTRIBUTING.md) and followed its instructions?_
- [ ] Test automation
_Does this repository's tests pass with your changes?_
- [ ] Documentation
_Does any documentation need to be updated with your changes?_
- [ ] Check Tools Provider
_Have you tested the changes with existing tools, i.e. Odo, Che, Console? (See [devfile registry contributing guide](https://github.com/devfile/registry/blob/main/CONTRIBUTING.md) on how to test changes)_


### How to test changes / Special notes to the reviewer: