### PR TITLE
Update nodejs-svelte stack

### DIFF
--- a/stacks/nodejs-svelte/1.2.1/devfile.yaml
+++ b/stacks/nodejs-svelte/1.2.1/devfile.yaml
@@ -1,0 +1,48 @@
+schemaVersion: 2.2.0
+metadata:
+  name: nodejs-svelte
+  displayName: Svelte
+  description: "Svelte is a radical new approach to building user interfaces.
+    Whereas traditional frameworks like React and Vue do the bulk of their work in the browser, Svelte shifts that work into a compile step that happens when you build your app."
+  icon: https://raw.githubusercontent.com/devfile-samples/devfile-stack-icons/main/svelte.svg
+  tags:
+    - Node.js
+    - Svelte
+  projectType: Svelte
+  language: TypeScript
+  provider: Red Hat
+  version: 1.2.1
+starterProjects:
+  - name: nodejs-svelte-starter
+    git:
+      checkoutFrom:
+        revision: main
+      remotes:
+        origin: https://github.com/devfile-samples/devfile-stack-nodejs-svelte.git
+components:
+  - container:
+      endpoints:
+        - name: https-svelte
+          targetPort: 3000
+          protocol: https
+      image: registry.access.redhat.com/ubi8/nodejs-18:1-94
+      args: ['tail', '-f', '/dev/null']
+      memoryLimit: 1024Mi
+    name: runtime
+commands:
+  - exec:
+      commandLine: npm install
+      component: runtime
+      group:
+        isDefault: true
+        kind: build
+      workingDir: ${PROJECT_SOURCE}
+    id: install
+  - exec:
+      commandLine: npm run dev
+      component: runtime
+      group:
+        isDefault: true
+        kind: run
+      workingDir: ${PROJECT_SOURCE}
+    id: run

--- a/stacks/nodejs-svelte/stack.yaml
+++ b/stacks/nodejs-svelte/stack.yaml
@@ -6,6 +6,7 @@ displayName: Svelte
 icon: https://raw.githubusercontent.com/devfile-samples/devfile-stack-icons/main/svelte.svg
 versions:
   - version: 1.0.3
-    default: true # should have one and only one default version
   - version: 1.1.0
   - version: 1.2.0
+  - version: 1.2.1
+    default: true # should have one and only one default version


### PR DESCRIPTION
### What does this PR do?:

Updates nodejs-svelte stack:
- Add new version 1.2.1
- Set https protocol for the endpoint
- Set 1.2.1 version as a default one

![screenshot-che-dogfooding apps che-dev x6e0 p1 openshiftapps com-2024 03 20-12_34_10](https://github.com/devfile/registry/assets/1271546/43edc502-0dd1-49d6-9364-b36225034c9c)

![screenshot-svor-nodejs-svelte-https-svelte apps che-dev x6e0 p1 openshiftapps com-2024 03 20-12_33_09](https://github.com/devfile/registry/assets/1271546/74ea058e-bbfd-4705-8fc8-119dd235fa22)


### Which issue(s) this PR fixes:
https://github.com/eclipse/che/issues/22869

### PR acceptance criteria:

- [ ] Contributing guide
_Have you read the [devfile registry contributing guide](https://github.com/devfile/registry/blob/main/CONTRIBUTING.md) and followed its instructions?_
- [ ] Test automation
_Does this repository's tests pass with your changes?_
- [ ] Documentation
_Does any documentation need to be updated with your changes?_
- [ ] Check Tools Provider
_Have you tested the changes with existing tools, i.e. Odo, Che, Console? (See [devfile registry contributing guide](https://github.com/devfile/registry/blob/main/CONTRIBUTING.md) on how to test changes)_


### How to test changes / Special notes to the reviewer:
Try it out on Developer Sandbox:

[![Contribute](https://www.eclipse.org/che/contribute.svg)](https://workspaces.openshift.com/#/https://raw.githubusercontent.com/devfile/registry/sv-update-svelte/stacks/nodejs-svelte/1.2.1/devfile.yaml)