### PR TITLE
Update nodejs-nextjs stack

### DIFF
--- a/stacks/nodejs-nextjs/1.2.1/devfile.yaml
+++ b/stacks/nodejs-nextjs/1.2.1/devfile.yaml
@@ -1,0 +1,50 @@
+schemaVersion: 2.2.2
+metadata:
+  name: nodejs-nextjs
+  displayName: Next.js
+  description: "Next.js gives you the best developer experience with all the features you need for production:
+    hybrid static & server rendering, TypeScript support, smart bundling, route pre-fetching, and more.
+    No config needed."
+  icon: https://raw.githubusercontent.com/devfile-samples/devfile-stack-icons/main/next-js.svg
+  tags:
+    - Node.js
+    - Next.js
+  projectType: Next.js
+  language: TypeScript
+  provider: Red Hat
+  version: 1.2.1
+starterProjects:
+  - name: nodejs-nextjs-starter
+    git:
+      checkoutFrom:
+        revision: main
+      remotes:
+        origin: https://github.com/devfile-samples/devfile-stack-nodejs-nextjs.git
+components:
+  - container:
+      endpoints:
+        - name: https-nextjs
+          protocol: https
+          targetPort: 3000
+      image: registry.access.redhat.com/ubi8/nodejs-18:1-94
+      command: ['tail', '-f', '/dev/null']
+      memoryLimit: 1024Mi
+    name: runtime
+commands:
+  - exec:
+      commandLine: npm install
+      component: runtime
+      group:
+        isDefault: true
+        kind: build
+      workingDir: ${PROJECT_SOURCE}
+    id: install
+  - exec:
+      commandLine: npm run dev
+      component: runtime
+      group:
+        isDefault: true
+        kind: run
+      hotReloadCapable: true
+      workingDir: ${PROJECT_SOURCE}
+    id: run

--- a/stacks/nodejs-nextjs/stack.yaml
+++ b/stacks/nodejs-nextjs/stack.yaml
@@ -8,5 +8,6 @@ icon: https://raw.githubusercontent.com/devfile-samples/devfile-stack-icons/main
 versions:
   - version: 1.0.3
   - version: 1.1.0
-    default: true # should have one and only one default version
   - version: 1.2.0
+  - version: 1.2.1
+    default: true # should have one and only one default version


### PR DESCRIPTION
### What does this PR do?:
Updates `nodejs-nextjs` stack:

- Add new version: `1.2.1`
- Set `schemaVersion: 2.2.2`
- Set `https` protocol for the endpoint
- Set `1.2.1` version as a default one

<img width="1781" alt="image" src="https://github.com/devfile/registry/assets/5676062/1ac355b5-d6dd-41d3-a0d2-0d5ccf38a864">

### Which issue(s) this PR fixes:
https://github.com/eclipse/che/issues/22869

### PR acceptance criteria:

- [ ] Contributing guide
_Have you read the [devfile registry contributing guide](https://github.com/devfile/registry/blob/main/CONTRIBUTING.md) and followed its instructions?_
- [ ] Test automation
_Does this repository's tests pass with your changes?_
- [ ] Documentation
_Does any documentation need to be updated with your changes?_
- [ ] Check Tools Provider
_Have you tested the changes with existing tools, i.e. Odo, Che, Console? (See [devfile registry contributing guide](https://github.com/devfile/registry/blob/main/CONTRIBUTING.md) on how to test changes)_


### How to test changes / Special notes to the reviewer:
You can use the following link to start a workspace for testing:
https://workspaces.openshift.com/#https://raw.githubusercontent.com/RomanNikitenko/registry/update-nextjs/stacks/nodejs-nextjs/1.2.1/devfile.yaml


Signed-off-by: Roman Nikitenko <rnikiten@redhat.com>

rh-pre-commit.version: 2.2.0
rh-pre-commit.check-secrets: ENABLED
