### PR TITLE
TEMP ignore schemaVersions 2.2.2 and 2.2.1 due to odo incompatibility

### DIFF
--- a/tests/odov3/odo_test.go
+++ b/tests/odov3/odo_test.go
@@ -71,12 +71,13 @@ func TestOdo(t *testing.T) {
 		devfile, _, err := devfile.ParseDevfileAndValidate(parserArgs)
 		g.Expect(err).To(BeNil())
 
+		schemaVersion := devfile.Data.GetSchemaVersion()
 		name := devfile.Data.GetMetadata().Name
 		version := devfile.Data.GetMetadata().Version
 		starterProjects, err := devfile.Data.GetStarterProjects(common.DevfileOptions{})
 		g.Expect(err).To(BeNil())
 
-		stack := Stack{name: name, version: version, path: path, starterProjects: starterProjects, base: base}
+		stack := Stack{name: name, schemaVersion: schemaVersion, version: version, path: path, starterProjects: starterProjects, base: base}
 
 		stacks = append(stacks, stack)
 	}
@@ -151,6 +152,12 @@ var _ = Describe("test starter projects from devfile stacks", func() {
 
 	for _, stack := range stacks {
 		stack := stack
+
+		// TEMP: ignore testing schema versions 2.2.2 & 2.2.1 due to odo incompatibility
+		// related issue: https://github.com/devfile/api/issues/1494
+		if stack.schemaVersion == "2.2.1" || stack.schemaVersion == "2.2.2" {
+			continue
+		}
 
 		if len(stack.starterProjects) == 0 {
 			It(fmt.Sprintf("stack: %s version: %s no_starter", stack.name, stack.version), func() {

--- a/tests/odov3/types.go
+++ b/tests/odov3/types.go
@@ -32,6 +32,7 @@ type ForwardedPort struct {
 type Stack struct {
 	name            string
 	version         string
+	schemaVersion   string
 	path            string
 	base            string
 	starterProjects []v1alpha2.StarterProject


### PR DESCRIPTION
### What does this PR do?:

This PR disables temporarily (until the https://github.com/devfile/api/issues/1494 is completed) the `schemaVersions 2.2.1 & 2.2.2` . Once the related issue is completed this change should be reverted.

### Which issue(s) this PR fixes:

temporarily fixes https://github.com/devfile/api/issues/1494

### PR acceptance criteria:

- [ ] Contributing guide
_Have you read the [devfile registry contributing guide](https://github.com/devfile/registry/blob/main/CONTRIBUTING.md) and followed its instructions?_
- [ ] Test automation
_Does this repository's tests pass with your changes?_
- [ ] Documentation
_Does any documentation need to be updated with your changes?_
- [ ] Check Tools Provider
_Have you tested the changes with existing tools, i.e. Odo, Che, Console? (See [devfile registry contributing guide](https://github.com/devfile/registry/blob/main/CONTRIBUTING.md) on how to test changes)_


### How to test changes / Special notes to the reviewer: