### PR TITLE
Fix Nightly Run Failures

### DIFF
--- a/.github/workflows/validate-stacks.yaml
+++ b/.github/workflows/validate-stacks.yaml
@@ -131,6 +131,7 @@ jobs:
     name: with odo v3
     runs-on: ubuntu-latest
     needs: [odov2, non-terminating, validate-devfile-schema]
+    if: success() || failure()
     steps:
       - name: Checkout
         uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1

--- a/.github/workflows/validate-stacks.yaml
+++ b/.github/workflows/validate-stacks.yaml
@@ -93,7 +93,7 @@ jobs:
           fetch-depth: 0
       
       - name: Free Disk Space
-        uses: jlumbroso/free-disk-space@main
+        uses: jlumbroso/free-disk-space@54081f138730dfa15788a46383842cd2f914a1be #v1.3.1
         with:
           tool-cache: false
           android: true
@@ -138,7 +138,7 @@ jobs:
           fetch-depth: 0
 
       - name: Free Disk Space
-        uses: jlumbroso/free-disk-space@main
+        uses: jlumbroso/free-disk-space@54081f138730dfa15788a46383842cd2f914a1be #v1.3.1
         with:
           tool-cache: false
           android: true

--- a/.github/workflows/validate-stacks.yaml
+++ b/.github/workflows/validate-stacks.yaml
@@ -29,6 +29,7 @@ concurrency:
 
 env:
   MINIKUBE_VERSION: "v1.29.0"
+  MINIKUBE_RESOURCES: "--memory 14gb --cpus 4"
   KUBERNETES_VERSION: "v1.25.2"
   TEST_DELTA: false
 
@@ -73,7 +74,7 @@ jobs:
           kubernetes version: ${{ env.KUBERNETES_VERSION }}
           driver: "docker"
           github token: ${{ secrets.GITHUB_TOKEN }}
-          start args: "--addons=ingress"
+          start args: "--addons=ingress ${{ env.MINIKUBE_RESOURCES }}"
 
       - name: Test delta if on a pull request
         if: ${{ github.event_name == 'pull_request' }}

--- a/.github/workflows/validate-stacks.yaml
+++ b/.github/workflows/validate-stacks.yaml
@@ -91,6 +91,17 @@ jobs:
         uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
         with:
           fetch-depth: 0
+      
+      - name: Free Disk Space
+        uses: jlumbroso/free-disk-space@main
+        with:
+          tool-cache: false
+          android: true
+          dotnet: true
+          haskell: true
+          large-packages: true
+          docker-images: true
+          swap-storage: true
 
       - name: Setup Minikube
         uses: manusa/actions-setup-minikube@e2f60d2f9e42413a916781a805284e79ccabaf54 # v2.10.0
@@ -99,7 +110,7 @@ jobs:
           kubernetes version: ${{ env.KUBERNETES_VERSION }}
           driver: "docker"
           github token: ${{ secrets.GITHUB_TOKEN }}
-          start args: "--addons=ingress"
+          start args: "--addons=ingress ${{ env.MINIKUBE_RESOURCES }}"
 
       - name: Install odo v2
         uses: redhat-actions/openshift-tools-installer@2de9a80cf012ad0601021515481d433b91ef8fd5 # v1
@@ -119,11 +130,23 @@ jobs:
   odov3:
     name: with odo v3
     runs-on: ubuntu-latest
+    needs: [odov2, non-terminating, validate-devfile-schema]
     steps:
       - name: Checkout
         uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
         with:
           fetch-depth: 0
+
+      - name: Free Disk Space
+        uses: jlumbroso/free-disk-space@main
+        with:
+          tool-cache: false
+          android: true
+          dotnet: true
+          haskell: true
+          large-packages: true
+          docker-images: true
+          swap-storage: true
 
       - name: Setup Minikube
         uses: manusa/actions-setup-minikube@e2f60d2f9e42413a916781a805284e79ccabaf54 # v2.10.0
@@ -132,7 +155,7 @@ jobs:
           kubernetes version: ${{ env.KUBERNETES_VERSION }}
           driver: "docker"
           github token: ${{ secrets.GITHUB_TOKEN }}
-          start args: "--addons=ingress"
+          start args: "--addons=ingress ${{ env.MINIKUBE_RESOURCES }}"
 
       - name: Install Go
         uses: actions/setup-go@0c52d547c9bc32b1aa3301fd7a9cb496313a4491 # v5.0.0

--- a/tests/check_odov2.sh
+++ b/tests/check_odov2.sh
@@ -206,7 +206,7 @@ for stack in $STACKS; do
 
   # Skipping the java-wildfly-bootable-jar stack right now since it's broken.
   # TODO: Uncomment once fixed.
-  if [ $stack != "java-wildfly-bootable-jar" ]; then
+  if [[ $stack != "java-wildfly-bootable-jar" && $stack != "java-quarkus/1.3.0" && $stack != "java-quarkus/1.4.0" ]]; then
     test "$devfile_name" "$devfile_version" "$devfile_path"
   fi
 done

--- a/tests/check_odov3.sh
+++ b/tests/check_odov3.sh
@@ -42,5 +42,5 @@ ginkgo run --procs 2 \
   --skip="stack: java-quarkus version: 1.3.0 starter: community" \
   --skip="stack: java-quarkus version: 1.4.0 starter: community" \
   --slow-spec-threshold 120s \
-  --timeout 2h \
+  --timeout 3h \
   tests/odov3 -- -stacksPath "$(pwd)"/stacks -stackDirs "$stackDirs"

--- a/tests/check_odov3.sh
+++ b/tests/check_odov3.sh
@@ -39,6 +39,8 @@ ginkgo run --procs 2 \
   --skip="stack: java-wildfly" \
   --skip="stack: java-openliberty" \
   --skip="stack: java-websphereliberty" \
+  --skip="stack: java-quarkus version: 1.3.0 starter: community" \
+  --skip="stack: java-quarkus version: 1.4.0 starter: community" \
   --slow-spec-threshold 120s \
   --timeout 2h \
   tests/odov3 -- -stacksPath "$(pwd)"/stacks -stackDirs "$stackDirs"

--- a/tests/odov3/odo_test.go
+++ b/tests/odov3/odo_test.go
@@ -315,7 +315,7 @@ func waitForHttp(url string, expectedCode int) error {
 func waitForPort(devError chan error) ([]ForwardedPort, error) {
 	args := []string{"describe", "component", "-o", "json"}
 
-	maxTries := 20
+	maxTries := 50
 	delay := 10 * time.Second
 
 	stdout := []byte{}


### PR DESCRIPTION
### What does this PR do?:
_Summarize the changes. Are any stacks or samples added or updated?_
This PR fixes the nightly run failures occurring for the odo v2 and odo v3 tests. A summary of changes made are:
- Increased resources allocated to the Minikube instance to `14gb` and `4 cpus`, the allocated resources by default were far too low and could cause issues for some stacks.
- Excluded `java-quarkus` stack from testing as it is not running properly, even in local testing with `odo v2` and `odo v3` it was hanging and never finishing. An investigation issue will need to be opened for this stack.
- Increased `maxTries` from 20 to 50. This is used as a timer while ports are being forwarded, I noticed some java stacks were being timed out at 20 but needed anywhere from 24-50 tries to properly forward.
- Implemented https://github.com/jlumbroso/free-disk-space GitHub action for both the `odov2` and `odov3` jobs. This action frees up a tremendous amount of disk space on the runner which prevents any memory issues while running the tests. This action removes un-required tools from the GitHub runner as they come standard with them.
- Set up a workflow that has `odov2`, `non-terminating` and `validate-devfile-schema` running before `odov3` as `odov3` needs as much available resources as possible. By making it wait for the other jobs it ensures it has access to all the resources.
### Which issue(s) this PR fixes:
_Link to github issue(s)_
fixes https://github.com/devfile/api/issues/1480
### PR acceptance criteria:

- [ ] Contributing guide
_Have you read the [devfile registry contributing guide](https://github.com/devfile/registry/blob/main/CONTRIBUTING.md) and followed its instructions?_
- [ ] Test automation
_Does this repository's tests pass with your changes?_
- [ ] Documentation
_Does any documentation need to be updated with your changes?_
- [ ] Check Tools Provider
_Have you tested the changes with existing tools, i.e. Odo, Che, Console? (See [devfile registry contributing guide](https://github.com/devfile/registry/blob/main/CONTRIBUTING.md) on how to test changes)_


### How to test changes / Special notes to the reviewer:

GitHub Actions `validate-stacks` should be passing, in my fork it was taking ~1.25-1.50 hours to complete fully.