### PR TITLE
Explicitly set java version as a query parameter in the java-quarkus zip urls

### DIFF
--- a/stacks/java-quarkus/1.3.0/devfile.yaml
+++ b/stacks/java-quarkus/1.3.0/devfile.yaml
@@ -7,6 +7,7 @@ metadata:
   tags:
     - Java
     - Quarkus
+    - Deprecated
   projectType: Quarkus
   language: Java
   version: 1.3.0

--- a/stacks/java-quarkus/1.3.1/devfile.yaml
+++ b/stacks/java-quarkus/1.3.1/devfile.yaml
@@ -1,4 +1,4 @@
-schemaVersion: 2.2.0
+schemaVersion: 2.1.0
 metadata:
   name: java-quarkus
   displayName: Quarkus Java
@@ -7,18 +7,17 @@ metadata:
   tags:
     - Java
     - Quarkus
-    - Deprecated
   projectType: Quarkus
   language: Java
-  version: 1.4.0
+  version: 1.3.1
   website: https://quarkus.io
 starterProjects:
   - name: community
     zip:
-      location: https://code.quarkus.io/d?e=io.quarkus%3Aquarkus-resteasy&e=io.quarkus%3Aquarkus-micrometer&e=io.quarkus%3Aquarkus-smallrye-health&e=io.quarkus%3Aquarkus-openshift&cn=devfile
+      location: https://code.quarkus.io/d?e=io.quarkus%3Aquarkus-resteasy&e=io.quarkus%3Aquarkus-micrometer&e=io.quarkus%3Aquarkus-smallrye-health&e=io.quarkus%3Aquarkus-openshift&cn=devfile&j=17
   - name: redhat-product
     zip:
-      location: https://code.quarkus.redhat.com/d?e=io.quarkus%3Aquarkus-resteasy&e=io.quarkus%3Aquarkus-smallrye-health&e=io.quarkus%3Aquarkus-openshift
+      location: https://code.quarkus.redhat.com/d?e=io.quarkus%3Aquarkus-resteasy&e=io.quarkus%3Aquarkus-smallrye-health&e=io.quarkus%3Aquarkus-openshift&j=17
 components:
   - name: tools
     container:
@@ -30,9 +29,8 @@ components:
         - name: m2
           path: /home/user/.m2
       endpoints:
-        - name: https-quarkus
+        - name: http-quarkus
           targetPort: 8080
-          protocol: https
         - exposure: none
           name: debug
           targetPort: 5858

--- a/stacks/java-quarkus/1.4.1/devfile.yaml
+++ b/stacks/java-quarkus/1.4.1/devfile.yaml
@@ -7,18 +7,17 @@ metadata:
   tags:
     - Java
     - Quarkus
-    - Deprecated
   projectType: Quarkus
   language: Java
-  version: 1.4.0
+  version: 1.4.1
   website: https://quarkus.io
 starterProjects:
   - name: community
     zip:
-      location: https://code.quarkus.io/d?e=io.quarkus%3Aquarkus-resteasy&e=io.quarkus%3Aquarkus-micrometer&e=io.quarkus%3Aquarkus-smallrye-health&e=io.quarkus%3Aquarkus-openshift&cn=devfile
+      location: https://code.quarkus.io/d?e=io.quarkus%3Aquarkus-resteasy&e=io.quarkus%3Aquarkus-micrometer&e=io.quarkus%3Aquarkus-smallrye-health&e=io.quarkus%3Aquarkus-openshift&cn=devfile&j=17
   - name: redhat-product
     zip:
-      location: https://code.quarkus.redhat.com/d?e=io.quarkus%3Aquarkus-resteasy&e=io.quarkus%3Aquarkus-smallrye-health&e=io.quarkus%3Aquarkus-openshift
+      location: https://code.quarkus.redhat.com/d?e=io.quarkus%3Aquarkus-resteasy&e=io.quarkus%3Aquarkus-smallrye-health&e=io.quarkus%3Aquarkus-openshift&j=17
 components:
   - name: tools
     container:

--- a/stacks/java-quarkus/stack.yaml
+++ b/stacks/java-quarkus/stack.yaml
@@ -4,5 +4,7 @@ displayName: Quarkus Java
 icon: https://design.jboss.org/quarkus/logo/final/SVG/quarkus_icon_rgb_default.svg
 versions:
   - version: 1.3.0
+  - version: 1.3.1
   - version: 1.4.0
+  - version: 1.4.1
     default: true # should have one and only one default version


### PR DESCRIPTION
### What does this PR do?:
Explicitly set java version in the java-quarkus zip urls to java 17, in order to fix the error from the `init-compile` command:
```
INFO] Recompiling the module because of changed dependency.
[INFO] Compiling 2 source files with javac [debug release 21] to target/classes
[INFO] ------------------------------------------------------------------------
[INFO] BUILD FAILURE
[INFO] ------------------------------------------------------------------------
[INFO] Total time:  15.345 s
[INFO] Finished at: 2024-04-12T10:05:13Z
[INFO] ------------------------------------------------------------------------
[ERROR] Failed to execute goal org.apache.maven.plugins:maven-compiler-plugin:3.12.1:compile (default-compile) on project code-with-quarkus: Fatal error compiling: error: release version 21 not supported -> [Help 1]
```

### Which issue(s) this PR fixes:
N/A

### PR acceptance criteria:

- [ ] Contributing guide
_Have you read the [devfile registry contributing guide](https://github.com/devfile/registry/blob/main/CONTRIBUTING.md) and followed its instructions?_
- [ ] Test automation
_Does this repository's tests pass with your changes?_
- [ ] Documentation
_Does any documentation need to be updated with your changes?_
- [ ] Check Tools Provider
_Have you tested the changes with existing tools, i.e. Odo, Che, Console? (See [devfile registry contributing guide](https://github.com/devfile/registry/blob/main/CONTRIBUTING.md) on how to test changes)_


### How to test changes / Special notes to the reviewer: