### PR TITLE
Add a 2.2.2 devfile version and set https endpoint to Spring Boot stack

### DIFF
--- a/stacks/java-springboot/1.4.0/devfile.yaml
+++ b/stacks/java-springboot/1.4.0/devfile.yaml
@@ -24,7 +24,7 @@ components:
       memoryLimit: 768Mi
       mountSources: true
       endpoints:
-        - name: https-springboot
+        - name: https-springbt
           targetPort: 8080
           protocol: https
         - exposure: none

--- a/stacks/java-springboot/1.4.0/devfile.yaml
+++ b/stacks/java-springboot/1.4.0/devfile.yaml
@@ -1,0 +1,66 @@
+schemaVersion: 2.2.2
+metadata:
+  name: java-springboot
+  displayName: Spring Boot®
+  description: Java application using Spring Boot® and OpenJDK 11
+  icon: https://raw.githubusercontent.com/devfile-samples/devfile-stack-icons/main/spring.svg
+  tags:
+    - Java
+    - Spring
+  projectType: springboot
+  language: Java
+  version: 1.4.0
+  globalMemoryLimit: 2674Mi
+starterProjects:
+  - name: springbootproject
+    git:
+      remotes:
+        origin: "https://github.com/odo-devfiles/springboot-ex.git"
+components:
+  - name: tools
+    container:
+      image: registry.access.redhat.com/ubi9/openjdk-17:1.17-1.1705573248
+      command: ["tail", "-f", "/dev/null"]
+      memoryLimit: 768Mi
+      mountSources: true
+      endpoints:
+        - name: https-springboot
+          targetPort: 8080
+          protocol: https
+        - exposure: none
+          name: debug
+          targetPort: 5858
+      volumeMounts:
+        - name: m2
+          path: /home/user/.m2
+      env:
+        - name: DEBUG_PORT
+          value: "5858"
+  - name: m2
+    volume:
+      size: 3Gi
+commands:
+  - id: build
+    exec:
+      component: tools
+      workingDir: ${PROJECT_SOURCE}
+      commandLine: "mvn clean -Dmaven.repo.local=/home/user/.m2/repository package -Dmaven.test.skip=true"
+      group:
+        kind: build
+        isDefault: true
+  - id: run
+    exec:
+      component: tools
+      workingDir: ${PROJECT_SOURCE}
+      commandLine: "mvn -Dmaven.repo.local=/home/user/.m2/repository spring-boot:run"
+      group:
+        kind: run
+        isDefault: true
+  - id: debug
+    exec:
+      component: tools
+      workingDir: ${PROJECT_SOURCE}
+      commandLine: "java -Xdebug -Xrunjdwp:server=y,transport=dt_socket,address=${DEBUG_PORT},suspend=n -jar target/*.jar"
+      group:
+        kind: debug
+        isDefault: true

--- a/stacks/java-springboot/2.2.0/devfile.yaml
+++ b/stacks/java-springboot/2.2.0/devfile.yaml
@@ -24,7 +24,7 @@ components:
       memoryLimit: 768Mi
       mountSources: true
       endpoints:
-        - name: https-springboot
+        - name: https-springbt
           targetPort: 8080
           protocol: https
         - exposure: none

--- a/stacks/java-springboot/2.2.0/devfile.yaml
+++ b/stacks/java-springboot/2.2.0/devfile.yaml
@@ -1,0 +1,94 @@
+schemaVersion: 2.2.2
+metadata:
+  name: java-springboot
+  displayName: Spring Boot®
+  description: Java application using Spring Boot® and OpenJDK 11
+  icon: https://raw.githubusercontent.com/devfile-samples/devfile-stack-icons/main/spring.svg
+  tags:
+    - Java
+    - Spring
+  projectType: springboot
+  language: Java
+  version: 2.2.0
+  globalMemoryLimit: 2674Mi
+starterProjects:
+  - name: springbootproject
+    git:
+      remotes:
+        origin: "https://github.com/odo-devfiles/springboot-ex.git"
+components:
+  - name: tools
+    container:
+      image: registry.access.redhat.com/ubi9/openjdk-17:1.17-1.1705573248
+      command: ['tail', '-f', '/dev/null']
+      memoryLimit: 768Mi
+      mountSources: true
+      endpoints:
+        - name: https-springboot
+          targetPort: 8080
+          protocol: https
+        - exposure: none
+          name: debug
+          targetPort: 5858
+      volumeMounts:
+        - name: m2
+          path: /home/user/.m2
+      env:
+        - name: DEBUG_PORT
+          value: "5858"
+  - name: m2
+    volume:
+      size: 3Gi
+  - name: build
+    image:
+      imageName: java-springboot-image:latest
+      dockerfile:
+        uri: docker/Dockerfile
+        buildContext: .
+        rootRequired: false
+  - name: deploy
+    kubernetes:
+      uri: kubernetes/deploy.yaml
+      endpoints:
+        - name: https-8081
+          targetPort: 8081
+          protocol: https
+commands:
+  - id: build
+    exec:
+      component: tools
+      workingDir: ${PROJECT_SOURCE}
+      commandLine: 'mvn clean -Dmaven.repo.local=/home/user/.m2/repository package -Dmaven.test.skip=true'
+      group:
+        kind: build
+        isDefault: true
+  - id: run
+    exec:
+      component: tools
+      workingDir: ${PROJECT_SOURCE}
+      commandLine: 'mvn -Dmaven.repo.local=/home/user/.m2/repository spring-boot:run'
+      group:
+        kind: run
+        isDefault: true
+  - id: debug
+    exec:
+      component: tools
+      workingDir: ${PROJECT_SOURCE}
+      commandLine: 'java -Xdebug -Xrunjdwp:server=y,transport=dt_socket,address=${DEBUG_PORT},suspend=n -jar target/*.jar'
+      group:
+        kind: debug
+        isDefault: true
+  - id: build-image
+    apply:
+      component: build
+  - id: deployk8s
+    apply:
+      component: deploy
+  - id: deploy
+    composite:
+      commands:
+        - build-image
+        - deployk8s
+      group:
+        kind: deploy
+        isDefault: true

--- a/stacks/java-springboot/2.2.0/docker/Dockerfile
+++ b/stacks/java-springboot/2.2.0/docker/Dockerfile
@@ -1,0 +1,27 @@
+####
+# This Dockerfile is used in order to build a container that runs the Spring Boot application
+#
+# Build the image with:
+#
+# docker build -f docker/Dockerfile -t springboot/sample-demo .
+#
+# Then run the container using:
+#
+# docker run -i --rm -p 8081:8081 springboot/sample-demo
+####
+FROM quay.io/devfile/maven:3.8.1-openjdk-17-slim
+
+WORKDIR /build
+
+# Build dependency offline to streamline build
+COPY pom.xml .
+RUN mvn dependency:go-offline
+
+COPY src src
+RUN mvn package -Dmaven.test.skip=true
+
+FROM registry.access.redhat.com/ubi9/openjdk-17-runtime:latest
+COPY --from=0 /build/target/demo-0.0.1-SNAPSHOT.jar /app/target/demo-0.0.1-SNAPSHOT.jar
+
+EXPOSE 8081
+ENTRYPOINT [ "java", "-jar", "/app/target/demo-0.0.1-SNAPSHOT.jar", "--server.port=8081" ]

--- a/stacks/java-springboot/2.2.0/kubernetes/deploy.yaml
+++ b/stacks/java-springboot/2.2.0/kubernetes/deploy.yaml
@@ -1,0 +1,41 @@
+kind: Service
+apiVersion: v1
+metadata:
+  name: my-java-springboot-svc
+spec:
+  ports:
+    - name: http-8081
+      port: 8081
+      protocol: TCP
+      targetPort: 8081
+  selector:
+    app: java-springboot-app
+---
+kind: Deployment
+apiVersion: apps/v1
+metadata:
+  name: my-java-springboot
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: java-springboot-app
+  template:
+    metadata:
+      labels:
+        app: java-springboot-app
+    spec:
+      containers:
+        - name: my-java-springboot
+          image: java-springboot-image:latest
+          ports:
+            - name: http
+              containerPort: 8081
+              protocol: TCP
+          resources:
+            requests:
+              memory: "180Mi"
+              cpu: "10m"
+            limits:
+              memory: "300Mi"
+              cpu: "100m"

--- a/stacks/java-springboot/stack.yaml
+++ b/stacks/java-springboot/stack.yaml
@@ -4,9 +4,11 @@ displayName: Spring Boot
 icon: https://raw.githubusercontent.com/devfile-samples/devfile-stack-icons/main/spring.svg
 versions:
   - version: 1.2.0
-  # 1.3.0: with JDK 17
+  # 1.3.0, 1.4.0: with JDK 17
   - version: 1.3.0
+  - version: 1.4.0
     default: true # should have one and only one default version
   - version: 2.0.0
-  # 2.1.0: with JDK 17
+  # 2.1.0, 2.2.0: with JDK 17
   - version: 2.1.0
+  - version: 2.2.0


### PR DESCRIPTION
### What does this PR do?:
Add a 2.2.2 devfile version and set https endpoint to Spring Boot stack.

### Which issue(s) this PR fixes:
1. Fix outdated "schemaVersion" attribute
2. Fix "Application is not available" error when launch Spring Boot application using Dev Spaces 3.12.0 / Eclipse Che Next"
![Screenshot from 2024-04-15 15-59-05](https://github.com/devfile/registry/assets/1197777/3fd8176a-545c-42ed-8c39-b46516b25a8e)

_Note_: It was necessary to truncate the endpoint name to handle the maximum endpoint name length limitation of 15 characters.

### PR acceptance criteria:

- [x] Contributing guide
_Have you read the [devfile registry contributing guide](https://github.com/devfile/registry/blob/main/CONTRIBUTING.md) and followed its instructions?_
- [ ] Test automation
_Does this repository's tests pass with your changes?_
- [x] Documentation
_Does any documentation need to be updated with your changes?_
- [x] Check Tools Provider
_Have you tested the changes with existing tools, i.e. Odo, Che, Console? (See [devfile registry contributing guide](https://github.com/devfile/registry/blob/main/CONTRIBUTING.md) on how to test changes)_


### How to test changes / Special notes to the reviewer: