### PR TITLE
Use odo nightly builds instead of 3.15.0

### DIFF
--- a/.github/workflows/validate-stacks.yaml
+++ b/.github/workflows/validate-stacks.yaml
@@ -165,7 +165,7 @@ jobs:
 
       - name: Install odo latest version
         run: |
-          curl -L https://s3.eu-de.cloud-object-storage.appdomain.cloud/odo-nightly-builds/odo-linux-amd64.sha256 -o odo
+          curl -L https://s3.eu-de.cloud-object-storage.appdomain.cloud/odo-nightly-builds/odo-linux-amd64 -o odo
           sudo install -m 0755 odo /usr/local/bin/odo
           mkdir -p $HOME/bin 
           cp ./odo $HOME/bin/odo

--- a/.github/workflows/validate-stacks.yaml
+++ b/.github/workflows/validate-stacks.yaml
@@ -165,8 +165,8 @@ jobs:
 
       - name: Install odo latest version
         run: |
-          curl -L https://s3.eu-de.cloud-object-storage.appdomain.cloud/odo-nightly-builds/odo-linux-amd64.sha256 -o odo.sha256
-          sudo apt install -m 0755 odo /usr/local/bin/odo
+          curl -L https://s3.eu-de.cloud-object-storage.appdomain.cloud/odo-nightly-builds/odo-linux-amd64.sha256 -o odo
+          sudo install -m 0755 odo /usr/local/bin/odo
           mkdir -p $HOME/bin 
           cp ./odo $HOME/bin/odo
           export PATH=$PATH:$HOME/bin

--- a/.github/workflows/validate-stacks.yaml
+++ b/.github/workflows/validate-stacks.yaml
@@ -166,7 +166,6 @@ jobs:
       - name: Install odo latest version
         run: |
           curl -L https://s3.eu-de.cloud-object-storage.appdomain.cloud/odo-nightly-builds/odo-linux-amd64.sha256 -o odo.sha256
-          echo "$(<odo.sha256)  odo" | shasum -a 256 --check
           sudo apt install -m 0755 odo /usr/local/bin/odo
           mkdir -p $HOME/bin 
           cp ./odo $HOME/bin/odo

--- a/.github/workflows/validate-stacks.yaml
+++ b/.github/workflows/validate-stacks.yaml
@@ -91,7 +91,7 @@ jobs:
         uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
         with:
           fetch-depth: 0
-      
+
       - name: Free Disk Space
         uses: jlumbroso/free-disk-space@54081f138730dfa15788a46383842cd2f914a1be #v1.3.1
         with:
@@ -163,16 +163,17 @@ jobs:
         with:
           go-version: "1.19"
 
-      - name: Install odo v3
-        uses: redhat-actions/openshift-tools-installer@2de9a80cf012ad0601021515481d433b91ef8fd5 # v1
-        with:
-          odo: "3.15.0"
+      - name: Install odo latest version
+        run: |
+          curl -L https://s3.eu-de.cloud-object-storage.appdomain.cloud/odo-nightly-builds/odo-linux-amd64.sha256 -o odo.sha256
+          echo "$(<odo.sha256)  odo" | shasum -a 256 --check
+          sudo apt install -m 0755 odo /usr/local/bin/odo
+          mkdir -p $HOME/bin 
+          cp ./odo $HOME/bin/odo
+          export PATH=$PATH:$HOME/bin
 
       - name: Install Ginkgo
         run: go install -mod=mod github.com/onsi/ginkgo/v2/ginkgo@v2.13.0
-
-      - name: Check odo version
-        run: odo version
 
       - name: Test delta if on a pull request
         if: ${{ github.event_name == 'pull_request' }}

--- a/.github/workflows/validate-stacks.yaml
+++ b/.github/workflows/validate-stacks.yaml
@@ -167,12 +167,12 @@ jobs:
         run: |
           curl -L https://s3.eu-de.cloud-object-storage.appdomain.cloud/odo-nightly-builds/odo-linux-amd64 -o odo
           sudo install -m 0755 odo /usr/local/bin/odo
-          mkdir -p $HOME/bin 
-          cp ./odo $HOME/bin/odo
-          export PATH=$PATH:$HOME/bin
 
       - name: Install Ginkgo
         run: go install -mod=mod github.com/onsi/ginkgo/v2/ginkgo@v2.13.0
+
+      - name: Check odo version
+        run: odo version
 
       - name: Test delta if on a pull request
         if: ${{ github.event_name == 'pull_request' }}

--- a/stacks/go/2.3.0/devfile.yaml
+++ b/stacks/go/2.3.0/devfile.yaml
@@ -30,8 +30,8 @@ components:
     kubernetes:
       uri: kubernetes/deploy.yaml
       endpoints:
-      - name: http-8080
-        targetPort: 8080
+      - name: http-8081
+        targetPort: 8081
   - container:
       endpoints:
         - name: http-go

--- a/stacks/go/2.3.0/devfile.yaml
+++ b/stacks/go/2.3.0/devfile.yaml
@@ -30,8 +30,8 @@ components:
     kubernetes:
       uri: kubernetes/deploy.yaml
       endpoints:
-      - name: http-8081
-        targetPort: 8081
+      - name: http-8080
+        targetPort: 8080
   - container:
       endpoints:
         - name: http-go


### PR DESCRIPTION
### What does this PR do?:
Simply updates the `check_odo3.sh` check to use the [nightly builds of odo](https://odo.dev/docs/overview/installation/#nightly-builds) instead of 3.15.0

### Which issue(s) this PR fixes:
fixes https://github.com/devfile/api/issues/1415

### PR acceptance criteria:

- [ ] Contributing guide
_Have you read the [devfile registry contributing guide](https://github.com/devfile/registry/blob/main/CONTRIBUTING.md) and followed its instructions?_
- [ ] Test automation
_Does this repository's tests pass with your changes?_
- [ ] Documentation
_Does any documentation need to be updated with your changes?_
- [ ] Check Tools Provider
_Have you tested the changes with existing tools, i.e. Odo, Che, Console? (See [devfile registry contributing guide](https://github.com/devfile/registry/blob/main/CONTRIBUTING.md) on how to test changes)_


### How to test changes / Special notes to the reviewer: