### PR TITLE
Add new version and set https endpoint to java-vertx

### DIFF
--- a/stacks/java-vertx/1.4.0/devfile.yaml
+++ b/stacks/java-vertx/1.4.0/devfile.yaml
@@ -1,0 +1,139 @@
+schemaVersion: 2.2.2
+metadata:
+  name: java-vertx
+  displayName: Vert.x Java
+  description: Java application using Vert.x and OpenJDK 11
+  icon: https://raw.githubusercontent.com/vertx-web-site/vertx-logo/master/vertx-logo.svg
+  tags:
+    - Java
+    - Vert.x
+  projectType: Vert.x
+  language: Java
+  version: 1.4.0
+starterProjects:
+  - name: vertx-http-example
+    git:
+      remotes:
+        origin: https://github.com/openshift-vertx-examples/vertx-http-example
+  - name: vertx-istio-circuit-breaker-booster
+    git:
+      remotes:
+        origin: https://github.com/openshift-vertx-examples/vertx-istio-circuit-breaker-booster
+  - name: vertx-istio-routing-booster
+    git:
+      remotes:
+        origin: https://github.com/openshift-vertx-examples/vertx-istio-routing-booster
+  - name: vertx-secured-http-example-redhat
+    git:
+      remotes:
+        origin: https://github.com/openshift-vertx-examples/vertx-secured-http-example-redhat
+  - name: vertx-crud-example-redhat
+    git:
+      remotes:
+        origin: https://github.com/openshift-vertx-examples/vertx-crud-example-redhat
+  - name: vertx-istio-security-booster
+    git:
+      remotes:
+        origin: https://github.com/openshift-vertx-examples/vertx-istio-security-booster
+  - name: vertx-crud-example
+    git:
+      remotes:
+        origin: https://github.com/openshift-vertx-examples/vertx-crud-example
+  - name: vertx-circuit-breaker-example
+    git:
+      remotes:
+        origin: https://github.com/openshift-vertx-examples/vertx-circuit-breaker-example
+  - name: vertx-configmap-example
+    git:
+      remotes:
+        origin: https://github.com/openshift-vertx-examples/vertx-configmap-example
+  - name: vertx-circuit-breaker-example-redhat
+    git:
+      remotes:
+        origin: https://github.com/openshift-vertx-examples/vertx-circuit-breaker-example-redhat
+  - name: vertx-cache-example-redhat
+    git:
+      remotes:
+        origin: https://github.com/openshift-vertx-examples/vertx-cache-example-redhat
+  - name: vertx-cache-example
+    git:
+      remotes:
+        origin: https://github.com/openshift-vertx-examples/vertx-cache-example
+  - name: vertx-secured-http-example
+    git:
+      remotes:
+        origin: https://github.com/openshift-vertx-examples/vertx-secured-http-example
+  - name: vertx-health-checks-example-redhat
+    git:
+      remotes:
+        origin: https://github.com/openshift-vertx-examples/vertx-health-checks-example-redhat
+  - name: vertx-http-example-redhat
+    git:
+      remotes:
+        origin: https://github.com/openshift-vertx-examples/vertx-http-example-redhat
+  - name: vertx-health-checks-example
+    git:
+      remotes:
+        origin: https://github.com/openshift-vertx-examples/vertx-health-checks-example
+  - name: vertx-configmap-example-redhat
+    git:
+      remotes:
+        origin: https://github.com/openshift-vertx-examples/vertx-configmap-example-redhat
+  - name: vertx-messaging-work-queue-booster
+    git:
+      remotes:
+        origin: https://github.com/openshift-vertx-examples/vertx-messaging-work-queue-booster
+  - name: vertx-istio-distributed-tracing-booster
+    git:
+      remotes:
+        origin: https://github.com/openshift-vertx-examples/vertx-istio-distributed-tracing-booster
+components:
+  - name: runtime
+    container:
+      endpoints:
+        - exposure: public
+          path: /
+          name: https-vertx
+          targetPort: 8080
+          protocol: https
+        - exposure: none
+          name: debug
+          targetPort: 5858
+      image: registry.access.redhat.com/ubi8/openjdk-11:1.18-2.1705602259
+      command: ["tail", "-f", "/dev/null"]
+      memoryLimit: 512Mi
+      mountSources: true
+      volumeMounts:
+        - name: m2
+          path: /home/user/.m2
+      env:
+        - name: DEBUG_PORT
+          value: '5858'
+  - name: m2
+    volume:
+      size: 3Gi
+commands:
+  - id: mvn-package
+    exec:
+      commandLine: mvn package -Dmaven.test.skip=true
+      component: runtime
+      workingDir: ${PROJECT_SOURCE}
+      group:
+        isDefault: true
+        kind: build
+  - id: run
+    exec:
+      commandLine: mvn io.reactiverse:vertx-maven-plugin:run
+      component: runtime
+      workingDir: ${PROJECT_SOURCE}
+      group:
+        isDefault: true
+        kind: run
+  - id: debug
+    exec:
+      commandLine: mvn io.reactiverse:vertx-maven-plugin:debug -Ddebug.port=${DEBUG_PORT}
+      component: runtime
+      workingDir: ${PROJECT_SOURCE}
+      group:
+        isDefault: true
+        kind: debug

--- a/stacks/java-vertx/stack.yaml
+++ b/stacks/java-vertx/stack.yaml
@@ -4,7 +4,7 @@ displayName: Vert.x Java
 icon: https://raw.githubusercontent.com/vertx-web-site/vertx-logo/master/vertx-logo.svg
 versions:
   - version: 1.2.0
-  # 1.3.0: runtime image is ubi8/openjdk-11
+  # 1.3.0, 1.4.0: runtime image is ubi8/openjdk-11
   - version: 1.3.0
-    default: true
- 
+  - version: 1.4.0
+    default: true # should have one and only one default version


### PR DESCRIPTION
### What does this PR do?:
Add a new version and set https endpoint to Java Vertx stack.

### Which issue(s) this PR fixes:
https://github.com/eclipse-che/che/issues/22869

### PR acceptance criteria:

- [ ] Contributing guide
_Have you read the [devfile registry contributing guide](https://github.com/devfile/registry/blob/main/CONTRIBUTING.md) and followed its instructions?_
- [ ] Test automation
_Does this repository's tests pass with your changes?_
- [ ] Documentation
_Does any documentation need to be updated with your changes?_
- [ ] Check Tools Provider
_Have you tested the changes with existing tools, i.e. Odo, Che, Console? (See [devfile registry contributing guide](https://github.com/devfile/registry/blob/main/CONTRIBUTING.md) on how to test changes)_


### How to test changes / Special notes to the reviewer: