### PR TITLE
Use maven wrapper script instead of the mvn in java-quarkus commands

### DIFF
--- a/stacks/java-quarkus/1.3.1/devfile.yaml
+++ b/stacks/java-quarkus/1.3.1/devfile.yaml
@@ -44,12 +44,12 @@ commands:
   - id: init-compile
     exec:
       component: tools
-      commandLine: 'mvn -Dmaven.repo.local=/home/user/.m2/repository compile'
+      commandLine: './mvnw -Dmaven.repo.local=/home/user/.m2/repository compile'
       workingDir: ${PROJECT_SOURCE}
   - id: dev-run
     exec:
       component: tools
-      commandLine: 'mvn -Dmaven.repo.local=/home/user/.m2/repository quarkus:dev -Dquarkus.http.host=0.0.0.0 -Djava.util.logging.manager=org.jboss.logmanager.LogManager'
+      commandLine: './mvnw -Dmaven.repo.local=/home/user/.m2/repository quarkus:dev -Dquarkus.http.host=0.0.0.0 -Djava.util.logging.manager=org.jboss.logmanager.LogManager'
       hotReloadCapable: true
       group:
         kind: run
@@ -58,7 +58,7 @@ commands:
   - id: dev-debug
     exec:
       component: tools
-      commandLine: 'mvn -Dmaven.repo.local=/home/user/.m2/repository quarkus:dev -Dquarkus.http.host=0.0.0.0 -Djava.util.logging.manager=org.jboss.logmanager.LogManager -Ddebug=${DEBUG_PORT}'
+      commandLine: './mvnw -Dmaven.repo.local=/home/user/.m2/repository quarkus:dev -Dquarkus.http.host=0.0.0.0 -Djava.util.logging.manager=org.jboss.logmanager.LogManager -Ddebug=${DEBUG_PORT}'
       hotReloadCapable: true
       group:
         kind: debug

--- a/stacks/java-quarkus/1.4.1/devfile.yaml
+++ b/stacks/java-quarkus/1.4.1/devfile.yaml
@@ -45,12 +45,12 @@ commands:
   - id: init-compile
     exec:
       component: tools
-      commandLine: 'mvn -Dmaven.repo.local=/home/user/.m2/repository compile'
+      commandLine: './mvnw -Dmaven.repo.local=/home/user/.m2/repository compile'
       workingDir: ${PROJECT_SOURCE}
   - id: dev-run
     exec:
       component: tools
-      commandLine: 'mvn -Dmaven.repo.local=/home/user/.m2/repository quarkus:dev -Dquarkus.http.host=0.0.0.0 -Djava.util.logging.manager=org.jboss.logmanager.LogManager'
+      commandLine: './mvnw -Dmaven.repo.local=/home/user/.m2/repository quarkus:dev -Dquarkus.http.host=0.0.0.0 -Djava.util.logging.manager=org.jboss.logmanager.LogManager'
       hotReloadCapable: true
       group:
         kind: run
@@ -59,7 +59,7 @@ commands:
   - id: dev-debug
     exec:
       component: tools
-      commandLine: 'mvn -Dmaven.repo.local=/home/user/.m2/repository quarkus:dev -Dquarkus.http.host=0.0.0.0 -Djava.util.logging.manager=org.jboss.logmanager.LogManager -Ddebug=${DEBUG_PORT}'
+      commandLine: './mvnw -Dmaven.repo.local=/home/user/.m2/repository quarkus:dev -Dquarkus.http.host=0.0.0.0 -Djava.util.logging.manager=org.jboss.logmanager.LogManager -Ddebug=${DEBUG_PORT}'
       hotReloadCapable: true
       group:
         kind: debug


### PR DESCRIPTION
### What does this PR do?:
In order to fix the maven build in the java quarkus sample, modify the devfile commands with maven wrapper script instead of the pure `mvn` call, see: https://github.com/eclipse-che/che/issues/22961

### Which issue(s) this PR fixes:
fixes https://github.com/eclipse-che/che/issues/22961
fixes devfile/api#1541

### PR acceptance criteria:

- [ ] Contributing guide
_Have you read the [devfile registry contributing guide](https://github.com/devfile/registry/blob/main/CONTRIBUTING.md) and followed its instructions?_
- [ ] Test automation
_Does this repository's tests pass with your changes?_
- [ ] Documentation
_Does any documentation need to be updated with your changes?_
- [ ] Check Tools Provider
_Have you tested the changes with existing tools, i.e. Odo, Che, Console? (See [devfile registry contributing guide](https://github.com/devfile/registry/blob/main/CONTRIBUTING.md) on how to test changes)_


### How to test changes / Special notes to the reviewer: