### PR TITLE
Update `Maven Java` stack

### DIFF
--- a/stacks/java-maven/1.3.1/devfile.yaml
+++ b/stacks/java-maven/1.3.1/devfile.yaml
@@ -1,0 +1,64 @@
+schemaVersion: 2.2.2
+metadata:
+  name: java-maven
+  displayName: Maven Java
+  description: Java application based on Maven 3.6 and OpenJDK 17
+  icon: https://raw.githubusercontent.com/devfile-samples/devfile-stack-icons/main/java-maven.jpg
+  tags:
+    - Java
+    - Maven
+  projectType: Maven
+  language: Java
+  version: 1.3.1
+starterProjects:
+  - name: springbootproject
+    git:
+      remotes:
+        origin: 'https://github.com/odo-devfiles/springboot-ex.git'
+components:
+  - name: tools
+    container:
+      image: registry.access.redhat.com/ubi9/openjdk-17:1.17-1.1705573248
+      command: ["tail", "-f", "/dev/null"]
+      memoryLimit: 512Mi
+      mountSources: true
+      endpoints:
+        - name: https-maven
+          targetPort: 8080
+          protocol: https
+        - exposure: none
+          name: debug
+          targetPort: 5858
+      volumeMounts:
+        - name: m2
+          path: /home/user/.m2
+      env:
+        - name: DEBUG_PORT
+          value: '5858'
+  - name: m2
+    volume: {}
+commands:
+  - id: mvn-package
+    exec:
+      component: tools
+      workingDir: ${PROJECT_SOURCE}
+      commandLine: 'mvn -Dmaven.repo.local=/home/user/.m2/repository package'
+      group:
+        kind: build
+        isDefault: true
+  - id: run
+    exec:
+      component: tools
+      workingDir: ${PROJECT_SOURCE}
+      commandLine: 'java -jar target/*.jar'
+      group:
+        kind: run
+        isDefault: true
+  - id: debug
+    exec:
+      component: tools
+      workingDir: ${PROJECT_SOURCE}
+      commandLine: 'java -Xdebug -Xrunjdwp:server=y,transport=dt_socket,address=${DEBUG_PORT},suspend=n -jar target/*.jar'
+      group:
+        kind: debug
+        isDefault: true

--- a/stacks/java-maven/stack.yaml
+++ b/stacks/java-maven/stack.yaml
@@ -6,4 +6,5 @@ versions:
   - version: 1.2.0
   # 1.3.0: with JDK 17
   - version: 1.3.0
+  - version: 1.3.1
     default: true # should have one and only one default version


### PR DESCRIPTION
### What does this PR do?:
_Summarize the changes. Are any stacks or samples added or updated?_
- update schema to `2.2.2`;
- use `https` protocol for the `java-maven` devfile

### Which issue(s) this PR fixes:
_Link to github issue(s)_
https://github.com/eclipse-che/che/issues/22869

### PR acceptance criteria:

- [ ] Contributing guide
_Have you read the [devfile registry contributing guide](https://github.com/devfile/registry/blob/main/CONTRIBUTING.md) and followed its instructions?_
- [ ] Test automation
_Does this repository's tests pass with your changes?_
- [ ] Documentation
_Does any documentation need to be updated with your changes?_
- [ ] Check Tools Provider
_Have you tested the changes with existing tools, i.e. Odo, Che, Console? (See [devfile registry contributing guide](https://github.com/devfile/registry/blob/main/CONTRIBUTING.md) on how to test changes)_


### How to test changes / Special notes to the reviewer:
https://workspaces.openshift.com/#https://raw.githubusercontent.com/azatsarynnyy/registry/java-maven-update/stacks/java-maven/1.3.1/devfile.yaml