### PR TITLE
Fix samples path in workflow

### DIFF
--- a/.github/workflows/validate-samples.yaml
+++ b/.github/workflows/validate-samples.yaml
@@ -61,4 +61,4 @@ jobs:
 
       - name: Validate samples
         if: ${{ env.STACKS != '' }}
-        run: STACKS_DIR=$(pwd)/samples/.cache bash tests/validate_devfile_schemas.sh --samples
+        run: STACKS_DIR=$(pwd)/.cache/samples bash tests/validate_devfile_schemas.sh --samples

--- a/tests/README.md
+++ b/tests/README.md
@@ -21,7 +21,7 @@
 - One can test the child samples using the [validate_devfile_schemas](./validate_devfile_schemas/) test suite by performing the following:
 ```sh
 export STACKS=$(bash tests/build_parents_file.sh)
-STACKS_DIR=samples/.cache bash tests/validate_devfile_schemas.sh --samples
+STACKS_DIR=.cache/samples bash tests/validate_devfile_schemas.sh --samples
 ```
 
 ## Validating non-terminating images


### PR DESCRIPTION
### What does this PR do?:
_Summarize the changes. Are any stacks or samples added or updated?_

Revised the cached samples path in https://github.com/devfile/registry/pull/397, missed the definition in the workflow which is causing current failures. Additional fix to documentation example.

### Which issue(s) this PR fixes:
_Link to github issue(s)_

### PR acceptance criteria:

- [X] Contributing guide
_Have you read the [devfile registry contributing guide](https://github.com/devfile/registry/blob/main/CONTRIBUTING.md) and followed its instructions?_
- [X] Test automation
_Does this repository's tests pass with your changes?_
- [x] Documentation
_Does any documentation need to be updated with your changes?_
- [ ] Check Tools Provider
_Have you tested the changes with existing tools, i.e. Odo, Che, Console? (See [devfile registry contributing guide](https://github.com/devfile/registry/blob/main/CONTRIBUTING.md) on how to test changes)_


### How to test changes / Special notes to the reviewer: