### PR TITLE
Multi Arch Image Building for Devfile Index

### DIFF
--- a/.ci/Dockerfile
+++ b/.ci/Dockerfile
@@ -17,9 +17,12 @@ FROM registry.access.redhat.com/ubi8/go-toolset:1.19 AS builder
 # Set user as root
 USER root
 
+# Automatically set when --platform flag is set, will default to amd64 if no platform is given
+ARG TARGETARCH=amd64
+
 # Install yq
 ENV YQ_VERSION=v4.44.1
-RUN curl -sL -O https://github.com/mikefarah/yq/releases/download/${YQ_VERSION}/yq_linux_amd64 -o /usr/local/bin/yq && mv ./yq_linux_amd64 /usr/local/bin/yq && chmod +x /usr/local/bin/yq
+RUN curl -sL -O https://github.com/mikefarah/yq/releases/download/${YQ_VERSION}/yq_linux_${TARGETARCH} -o /usr/local/bin/yq && mv ./yq_linux_${TARGETARCH} /usr/local/bin/yq && chmod +x /usr/local/bin/yq
 
 COPY . /registry
 

--- a/.ci/Dockerfile.offline
+++ b/.ci/Dockerfile.offline
@@ -17,9 +17,12 @@ FROM registry.access.redhat.com/ubi8/go-toolset:1.19 AS builder
 # Set user as root
 USER root
 
+# Automatically set when --platform flag is set, will default to amd64 if no platform is given
+ARG TARGETARCH=amd64
+
 # Install yq
 ENV YQ_VERSION=v4.44.1
-RUN curl -sL -O https://github.com/mikefarah/yq/releases/download/${YQ_VERSION}/yq_linux_amd64 -o /usr/local/bin/yq && mv ./yq_linux_amd64 /usr/local/bin/yq && chmod +x /usr/local/bin/yq
+RUN curl -sL -O https://github.com/mikefarah/yq/releases/download/${YQ_VERSION}/yq_linux_${TARGETARCH} -o /usr/local/bin/yq && mv ./yq_linux_${TARGETARCH} /usr/local/bin/yq && chmod +x /usr/local/bin/yq
 
 COPY . /registry
 

--- a/.ci/build-multi-arch.sh
+++ b/.ci/build-multi-arch.sh
@@ -1,0 +1,52 @@
+#!/bin/sh
+
+#
+# Copyright Red Hat
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Build the index container for the registry
+ABSOLUTE_PATH="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# Due to command differences between podman and docker we need to separate the process
+# for creating and adding images to a multi-arch manifest
+podman=${USE_PODMAN:-false}
+# Base Repository
+BASE_REPO="quay.io/devfile/devfile-index"
+BASE_TAG="next"
+DEFAULT_IMG="$BASE_REPO:$BASE_TAG"
+# Platforms to build for
+PLATFORMS="linux/amd64,linux/arm64"
+
+if [ ${podman} == true ]; then
+  echo "Executing with podman"
+
+  podman manifest create "$DEFAULT_IMG"
+
+  podman build --platform="$PLATFORMS" --manifest "$DEFAULT_IMG" --no-cache -f $ABSOLUTE_PATH/Dockerfile $ABSOLUTE_PATH/..
+
+  podman manifest push "$DEFAULT_IMG"
+
+  podman manifest rm "$DEFAULT_IMG"
+
+else
+  echo "Executing with docker"
+
+  docker buildx create --name index-builder
+
+  docker buildx use index-builder
+
+  docker buildx build --push --platform="$PLATFORMS" --tag "$DEFAULT_IMG" --provenance=false --no-cache -f $ABSOLUTE_PATH/Dockerfile $ABSOLUTE_PATH/..
+
+  docker buildx rm index-builder
+
+fi

--- a/.ci/build.sh
+++ b/.ci/build.sh
@@ -16,6 +16,16 @@ shopt -s expand_aliases
 
 ABSOLUTE_PATH="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 USE_PODMAN=${USE_PODMAN:-false}
+DEFAULT_ARCH="linux/amd64"
+
+# Check if different architecture was passed for image build
+# Will default to $DEFAULT_ARCH if unset
+if [ ! -z "$1" ]
+  then
+    arch="$1"
+else
+    arch="$DEFAULT_ARCH"
+fi
 
 if [[ ${USE_PODMAN} == true ]]; then
     alias docker=podman
@@ -24,7 +34,7 @@ fi
 
 if [ $# -eq 1 ] && [ $1 == "offline" ]
 then
-    docker build --no-cache -t devfile-index -f $ABSOLUTE_PATH/Dockerfile.offline $ABSOLUTE_PATH/..
+    docker build --no-cache --platform "${arch}" -t devfile-index -f $ABSOLUTE_PATH/Dockerfile.offline $ABSOLUTE_PATH/..
 else
-    docker build --no-cache -t devfile-index -f $ABSOLUTE_PATH/Dockerfile $ABSOLUTE_PATH/..
+    docker build --no-cache --platform "${arch}" -t devfile-index -f $ABSOLUTE_PATH/Dockerfile $ABSOLUTE_PATH/..
 fi

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -37,6 +37,8 @@ jobs:
         uses: actions/setup-go@cdcb36043654635271a94b9a6d1392de5bb323a7 # v5.0.1
         with:
           go-version: 1.19
+      - name: Set up QEMU # Enables arm64 image building
+        uses: docker/setup-qemu-action@68827325e0b33c7199eb31dd4e31fbe9023e06e3 
 
       - name: Check if devfile registry build is working
-        run: bash registry-repo/.ci/build.sh
+        run: bash registry-repo/.ci/build.sh && bash registry-repo/.ci/build.sh linux/arm64

--- a/.github/workflows/pushimge-next.yaml
+++ b/.github/workflows/pushimge-next.yaml
@@ -42,13 +42,13 @@ jobs:
         uses: actions/setup-go@cdcb36043654635271a94b9a6d1392de5bb323a7 # v5.0.1
         with:
           go-version: 1.13
+      - name: Set up QEMU # Enables arm64 image building
+        uses: docker/setup-qemu-action@68827325e0b33c7199eb31dd4e31fbe9023e06e3 
       - name: Login to Quay
         uses: docker/login-action@343f7c4344506bcbf9b4de18042ae17996df046d # v3.0.0
         with:
           registry: quay.io
           username: ${{ secrets.QUAY_USERNAME }}
           password: ${{ secrets.QUAY_PASSWORD }}
-      - name: Build the devfile-index docker image
-        run: bash registry-repo/.ci/build.sh
-      - name: Push the devfile-index docker image
-        run: bash registry-support/build-tools/push.sh quay.io/devfile/devfile-index:next
+      - name: Build and push the devfile-index docker image
+        run: bash registry-repo/.ci/build-multi-arch.sh

--- a/README.md
+++ b/README.md
@@ -30,7 +30,16 @@ If you are a stack owner and need to request an urgent refresh of <https://regis
 
 ### Build
 
-To build this devfile registry into a container image run `bash .ci/build.sh`. A container image will be built using the [devfile registry build tools](https://github.com/devfile/registry-support/tree/master/build-tools). By default these scripts will use `docker`, if you want to use `podman` you should first run `export USE_PODMAN=true` before executing the build script.
+To build this devfile registry into a container image run `bash .ci/build.sh`. A container image will be built using the [devfile registry build tools](https://github.com/devfile/registry-support/tree/master/build-tools). By default these scripts will use `docker` and be built for the `linux/amd64` architecture. 
+
+To build using `podman` first run:
+```
+export USE_PODMAN=true
+```
+To build for `linux/arm64` run:
+```
+bash .ci/build.sh linux/arm64
+```
 
 From there, push the container image to a container registry of your choice and deploy using a [devfile adopted devtool](https://devfile.io/docs/2.2.0/developing-with-devfiles#tools-that-provide-devfile-support) or one of the methods outlined [here](https://github.com/devfile/registry-support#deploy).
 


### PR DESCRIPTION
### What does this PR do?:
_Summarize the changes. Are any stacks or samples added or updated?_
These changes allow for the devfile index image to be built for multiple architectures and pushed to quay.io. The changes are:
- Addition of `build-multi-arch.sh` that takes care of building and pushing the index image to quay, built for both `linux/amd64` and `linux/arm64`. It has the ability to build with either docker or podman.
- Updated `build.sh` to allow for an argument to be passed that allows the user to build for a different architecture.
- Updated `Dockerfile` and `Dockerfile.offline` to dynamically set the yq architecture.
- Updated documentation for new `build.sh` script.
- Updated github workflows to use the new scripts and build/push multi-arch to quay

### Which issue(s) this PR fixes:
_Link to github issue(s)_
fixes https://github.com/devfile/api/issues/1547
fixes https://github.com/devfile/api/issues/1551
### PR acceptance criteria:

- [ ] Contributing guide
_Have you read the [devfile registry contributing guide](https://github.com/devfile/registry/blob/main/CONTRIBUTING.md) and followed its instructions?_
- [ ] Test automation
_Does this repository's tests pass with your changes?_
- [ ] Documentation
_Does any documentation need to be updated with your changes?_
- [ ] Check Tools Provider
_Have you tested the changes with existing tools, i.e. Odo, Che, Console? (See [devfile registry contributing guide](https://github.com/devfile/registry/blob/main/CONTRIBUTING.md) on how to test changes)_


### How to test changes / Special notes to the reviewer:
Since the Dockerfiles have `FROM quay.io/devfile/devfile-index-base:next` in them it is important that the PR opened for making the base image multi arch is merged prior to this. That PR can be found [here](https://github.com/devfile/registry-support/pull/245).