### PR TITLE
Replace starter projects from `odo-devfile` org

### DIFF
--- a/stacks/java-maven/1.3.0/devfile.yaml
+++ b/stacks/java-maven/1.3.0/devfile.yaml
@@ -14,7 +14,7 @@ starterProjects:
   - name: springbootproject
     git:
       remotes:
-        origin: 'https://github.com/odo-devfiles/springboot-ex.git'
+        origin: 'https://github.com/devfile-samples/springboot-ex.git'
 components:
   - name: tools
     container:

--- a/stacks/java-maven/1.3.1/devfile.yaml
+++ b/stacks/java-maven/1.3.1/devfile.yaml
@@ -14,7 +14,7 @@ starterProjects:
   - name: springbootproject
     git:
       remotes:
-        origin: 'https://github.com/odo-devfiles/springboot-ex.git'
+        origin: 'https://github.com/devfile-samples/springboot-ex.git'
 components:
   - name: tools
     container:

--- a/stacks/java-springboot/1.2.0/devfile.yaml
+++ b/stacks/java-springboot/1.2.0/devfile.yaml
@@ -15,7 +15,7 @@ starterProjects:
   - name: springbootproject
     git:
       remotes:
-        origin: "https://github.com/odo-devfiles/springboot-ex.git"
+        origin: "https://github.com/devfile-samples/springboot-ex.git"
 components:
   - name: tools
     container:

--- a/stacks/java-springboot/1.3.0/devfile.yaml
+++ b/stacks/java-springboot/1.3.0/devfile.yaml
@@ -15,7 +15,7 @@ starterProjects:
   - name: springbootproject
     git:
       remotes:
-        origin: "https://github.com/odo-devfiles/springboot-ex.git"
+        origin: "https://github.com/devfile-samples/springboot-ex.git"
 components:
   - name: tools
     container:

--- a/stacks/java-springboot/1.4.0/devfile.yaml
+++ b/stacks/java-springboot/1.4.0/devfile.yaml
@@ -15,7 +15,7 @@ starterProjects:
   - name: springbootproject
     git:
       remotes:
-        origin: "https://github.com/odo-devfiles/springboot-ex.git"
+        origin: "https://github.com/devfile-samples/springboot-ex.git"
 components:
   - name: tools
     container:

--- a/stacks/java-springboot/2.0.0/devfile.yaml
+++ b/stacks/java-springboot/2.0.0/devfile.yaml
@@ -15,7 +15,7 @@ starterProjects:
   - name: springbootproject
     git:
       remotes:
-        origin: "https://github.com/odo-devfiles/springboot-ex.git"
+        origin: "https://github.com/devfile-samples/springboot-ex.git"
 components:
   - name: tools
     container:

--- a/stacks/java-springboot/2.1.0/devfile.yaml
+++ b/stacks/java-springboot/2.1.0/devfile.yaml
@@ -15,7 +15,7 @@ starterProjects:
   - name: springbootproject
     git:
       remotes:
-        origin: "https://github.com/odo-devfiles/springboot-ex.git"
+        origin: "https://github.com/devfile-samples/springboot-ex.git"
 components:
   - name: tools
     container:

--- a/stacks/java-springboot/2.2.0/devfile.yaml
+++ b/stacks/java-springboot/2.2.0/devfile.yaml
@@ -15,7 +15,7 @@ starterProjects:
   - name: springbootproject
     git:
       remotes:
-        origin: "https://github.com/odo-devfiles/springboot-ex.git"
+        origin: "https://github.com/devfile-samples/springboot-ex.git"
 components:
   - name: tools
     container:

--- a/stacks/nodejs/2.1.1/devfile.yaml
+++ b/stacks/nodejs/2.1.1/devfile.yaml
@@ -15,6 +15,8 @@ metadata:
 starterProjects:
   - name: nodejs-starter
     git:
+      checkoutFrom:
+        revision: main
       remotes:
         origin: 'https://github.com/nodeshift-starters/devfile-sample.git'
 components:

--- a/stacks/nodejs/2.1.1/devfile.yaml
+++ b/stacks/nodejs/2.1.1/devfile.yaml
@@ -16,7 +16,7 @@ starterProjects:
   - name: nodejs-starter
     git:
       remotes:
-        origin: 'https://github.com/odo-devfiles/nodejs-ex.git'
+        origin: 'https://github.com/nodeshift-starters/devfile-sample.git'
 components:
   - name: runtime
     container:

--- a/stacks/nodejs/2.2.0/devfile.yaml
+++ b/stacks/nodejs/2.2.0/devfile.yaml
@@ -14,6 +14,8 @@ metadata:
 starterProjects:
   - name: nodejs-starter
     git:
+      checkoutFrom:
+        revision: main
       remotes:
         origin: 'https://github.com/nodeshift-starters/devfile-sample.git'
 components:

--- a/stacks/nodejs/2.2.0/devfile.yaml
+++ b/stacks/nodejs/2.2.0/devfile.yaml
@@ -15,7 +15,7 @@ starterProjects:
   - name: nodejs-starter
     git:
       remotes:
-        origin: 'https://github.com/odo-devfiles/nodejs-ex.git'
+        origin: 'https://github.com/nodeshift-starters/devfile-sample.git'
 components:
   - name: runtime
     container:

--- a/stacks/nodejs/2.2.1/devfile.yaml
+++ b/stacks/nodejs/2.2.1/devfile.yaml
@@ -14,6 +14,8 @@ metadata:
 starterProjects:
   - name: nodejs-starter
     git:
+      checkoutFrom:
+        revision: main
       remotes:
         origin: 'https://github.com/nodeshift-starters/devfile-sample.git'
 components:

--- a/stacks/nodejs/2.2.1/devfile.yaml
+++ b/stacks/nodejs/2.2.1/devfile.yaml
@@ -15,7 +15,7 @@ starterProjects:
   - name: nodejs-starter
     git:
       remotes:
-        origin: 'https://github.com/odo-devfiles/nodejs-ex.git'
+        origin: 'https://github.com/nodeshift-starters/devfile-sample.git'
 components:
   - name: runtime
     container:


### PR DESCRIPTION
### What does this PR do?:

This PR simply updates the `StarterProjects` for all versions of `java-springboot` and `nodejs` stacks. Those stacks were using starter projects from the [github.com/odo-devfiles](https://github.com/odo-devfiles) org. In order to move them to a better monitored org the PR makes the following changes:
* Replaces the https://github.com/odo-devfiles/springboot-ex starter project with its [fork](https://github.com/devfile-samples/springboot-ex) under devfile-samples.
* Replaces the https://github.com/odo-devfiles/nodejs-ex with the https://github.com/nodeshift-starters/devfile-sample.

The PR requires 3 approvals:
* @kadel as the owner of the `java-springboot` stack.
* @BethGriggs as the owner of the `nodejs` stack.
* @devfile/che-team as mentioned in the [registry stack PR review process](https://github.com/devfile/registry/blob/main/CONTRIBUTING.md#registry-stack-review-process).

### Which issue(s) this PR fixes:

Fixes https://github.com/devfile/api/issues/1604

### PR acceptance criteria:

- [ ] Contributing guide
_Have you read the [devfile registry contributing guide](https://github.com/devfile/registry/blob/main/CONTRIBUTING.md) and followed its instructions?_
- [ ] Test automation
_Does this repository's tests pass with your changes?_
- [ ] Documentation
_Does any documentation need to be updated with your changes?_
- [ ] Check Tools Provider
_Have you tested the changes with existing tools, i.e. Odo, Che, Console? (See [devfile registry contributing guide](https://github.com/devfile/registry/blob/main/CONTRIBUTING.md) on how to test changes)_


### How to test changes / Special notes to the reviewer:

The two new stacks have been tested with odo3 and minikube. Both have been deployed in https://workspaces.openshift.com/ successfully.