### PR TITLE
Use latest Java Spring Boot stack as default

### DIFF
--- a/stacks/java-springboot/stack.yaml
+++ b/stacks/java-springboot/stack.yaml
@@ -7,8 +7,8 @@ versions:
   # 1.3.0, 1.4.0: with JDK 17
   - version: 1.3.0
   - version: 1.4.0
-    default: true # should have one and only one default version
   - version: 2.0.0
   # 2.1.0, 2.2.0: with JDK 17
   - version: 2.1.0
   - version: 2.2.0
+    default: true # should have one and only one default version


### PR DESCRIPTION
it was set to a previous version originally to use a schema version 2.1 but in fact the default version was already upgraded to 2.2 3 months ago https://github.com/devfile/registry/commit/db0c583c550b7b8bf5ef3f3afbb85ade165f0d8b

### What does this PR do?:
_Summarize the changes. Are any stacks or samples added or updated?_

### Which issue(s) this PR fixes:
_Link to github issue(s)_

### PR acceptance criteria:

- [ ] Contributing guide
_Have you read the [devfile registry contributing guide](https://github.com/devfile/registry/blob/main/CONTRIBUTING.md) and followed its instructions?_
- [ ] Test automation
_Does this repository's tests pass with your changes?_
- [ ] Documentation
_Does any documentation need to be updated with your changes?_
- [ ] Check Tools Provider
_Have you tested the changes with existing tools, i.e. Odo, Che, Console? (See [devfile registry contributing guide](https://github.com/devfile/registry/blob/main/CONTRIBUTING.md) on how to test changes)_


### How to test changes / Special notes to the reviewer: