### PR TITLE
Use same case for Java language in Wildfly stacks than others

### DIFF
--- a/stacks/java-wildfly/2.0.0/devfile.yaml
+++ b/stacks/java-wildfly/2.0.0/devfile.yaml
@@ -8,7 +8,7 @@ metadata:
   icon: https://design.jboss.org/wildfly/logo/final/wildfly_logomark.svg
   tags: ["Community", "Java", "WildFly", "OpenJDK", "Maven", "JakartaEE"]
   projectType: 'wildfly'
-  language: 'java'
+  language: Java
 starterProjects:
   - name: numberguess
     description: WildFly Numberguess Quickstart

--- a/stacks/java-wildfly/2.0.1/devfile.yaml
+++ b/stacks/java-wildfly/2.0.1/devfile.yaml
@@ -8,7 +8,7 @@ metadata:
   icon: https://design.jboss.org/wildfly/logo/final/wildfly_logomark.svg
   tags: ['Java', 'WildFly']
   projectType: 'wildfly'
-  language: 'java'
+  language: Java
 variables:
   imageRegistry: 'quay.io'
   imageName: 'getting-started'

--- a/stacks/java-wildfly/2.0.2/devfile.yaml
+++ b/stacks/java-wildfly/2.0.2/devfile.yaml
@@ -8,7 +8,7 @@ metadata:
   icon: https://design.jboss.org/wildfly/logo/final/wildfly_logomark.svg
   tags: ['Java', 'WildFly']
   projectType: 'wildfly'
-  language: 'java'
+  language: Java
 variables:
   applicationName: 'start'
   nodeName: 'getting-started'


### PR DESCRIPTION
### What does this PR do?:

Use same case for Java language in Wildfly stacks than others

it avoids having Java and java listed in tooling
for instance:
![Screenshot from 2024-07-04 14-03-51](https://github.com/devfile/registry/assets/1105127/c5c9a7f6-4ca4-4415-ae3a-92b0a9014b51)


### Which issue(s) this PR fixes:
_Link to github issue(s)_

### PR acceptance criteria:

- [ ] Contributing guide
_Have you read the [devfile registry contributing guide](https://github.com/devfile/registry/blob/main/CONTRIBUTING.md) and followed its instructions?_
- [ ] Test automation
_Does this repository's tests pass with your changes?_
- [ ] Documentation
_Does any documentation need to be updated with your changes?_
- [ ] Check Tools Provider
_Have you tested the changes with existing tools, i.e. Odo, Che, Console? (See [devfile registry contributing guide](https://github.com/devfile/registry/blob/main/CONTRIBUTING.md) on how to test changes)_


### How to test changes / Special notes to the reviewer: