### PR TITLE
Remove LogManager property in Quarkus stacks (#1612)

### DIFF
--- a/stacks/java-quarkus/1.3.0/devfile.yaml
+++ b/stacks/java-quarkus/1.3.0/devfile.yaml
@@ -50,7 +50,7 @@ commands:
   - id: dev-run
     exec:
       component: tools
-      commandLine: 'mvn -Dmaven.repo.local=/home/user/.m2/repository quarkus:dev -Dquarkus.http.host=0.0.0.0 -Djava.util.logging.manager=org.jboss.logmanager.LogManager'
+      commandLine: 'mvn -Dmaven.repo.local=/home/user/.m2/repository quarkus:dev -Dquarkus.http.host=0.0.0.0'
       hotReloadCapable: true
       group:
         kind: run
@@ -59,7 +59,7 @@ commands:
   - id: dev-debug
     exec:
       component: tools
-      commandLine: 'mvn -Dmaven.repo.local=/home/user/.m2/repository quarkus:dev -Dquarkus.http.host=0.0.0.0 -Djava.util.logging.manager=org.jboss.logmanager.LogManager -Ddebug=${DEBUG_PORT}'
+      commandLine: 'mvn -Dmaven.repo.local=/home/user/.m2/repository quarkus:dev -Dquarkus.http.host=0.0.0.0 -Ddebug=${DEBUG_PORT}'
       hotReloadCapable: true
       group:
         kind: debug

--- a/stacks/java-quarkus/1.3.1/devfile.yaml
+++ b/stacks/java-quarkus/1.3.1/devfile.yaml
@@ -49,7 +49,7 @@ commands:
   - id: dev-run
     exec:
       component: tools
-      commandLine: './mvnw -Dmaven.repo.local=/home/user/.m2/repository quarkus:dev -Dquarkus.http.host=0.0.0.0 -Djava.util.logging.manager=org.jboss.logmanager.LogManager'
+      commandLine: './mvnw -Dmaven.repo.local=/home/user/.m2/repository quarkus:dev -Dquarkus.http.host=0.0.0.0'
       hotReloadCapable: true
       group:
         kind: run
@@ -58,7 +58,7 @@ commands:
   - id: dev-debug
     exec:
       component: tools
-      commandLine: './mvnw -Dmaven.repo.local=/home/user/.m2/repository quarkus:dev -Dquarkus.http.host=0.0.0.0 -Djava.util.logging.manager=org.jboss.logmanager.LogManager -Ddebug=${DEBUG_PORT}'
+      commandLine: './mvnw -Dmaven.repo.local=/home/user/.m2/repository quarkus:dev -Dquarkus.http.host=0.0.0.0 -Ddebug=${DEBUG_PORT}'
       hotReloadCapable: true
       group:
         kind: debug

--- a/stacks/java-quarkus/1.4.0/devfile.yaml
+++ b/stacks/java-quarkus/1.4.0/devfile.yaml
@@ -51,7 +51,7 @@ commands:
   - id: dev-run
     exec:
       component: tools
-      commandLine: 'mvn -Dmaven.repo.local=/home/user/.m2/repository quarkus:dev -Dquarkus.http.host=0.0.0.0 -Djava.util.logging.manager=org.jboss.logmanager.LogManager'
+      commandLine: 'mvn -Dmaven.repo.local=/home/user/.m2/repository quarkus:dev -Dquarkus.http.host=0.0.0.0'
       hotReloadCapable: true
       group:
         kind: run
@@ -60,7 +60,7 @@ commands:
   - id: dev-debug
     exec:
       component: tools
-      commandLine: 'mvn -Dmaven.repo.local=/home/user/.m2/repository quarkus:dev -Dquarkus.http.host=0.0.0.0 -Djava.util.logging.manager=org.jboss.logmanager.LogManager -Ddebug=${DEBUG_PORT}'
+      commandLine: 'mvn -Dmaven.repo.local=/home/user/.m2/repository quarkus:dev -Dquarkus.http.host=0.0.0.0 -Ddebug=${DEBUG_PORT}'
       hotReloadCapable: true
       group:
         kind: debug

--- a/stacks/java-quarkus/1.4.1/devfile.yaml
+++ b/stacks/java-quarkus/1.4.1/devfile.yaml
@@ -50,7 +50,7 @@ commands:
   - id: dev-run
     exec:
       component: tools
-      commandLine: './mvnw -Dmaven.repo.local=/home/user/.m2/repository quarkus:dev -Dquarkus.http.host=0.0.0.0 -Djava.util.logging.manager=org.jboss.logmanager.LogManager'
+      commandLine: './mvnw -Dmaven.repo.local=/home/user/.m2/repository quarkus:dev -Dquarkus.http.host=0.0.0.0'
       hotReloadCapable: true
       group:
         kind: run
@@ -59,7 +59,7 @@ commands:
   - id: dev-debug
     exec:
       component: tools
-      commandLine: './mvnw -Dmaven.repo.local=/home/user/.m2/repository quarkus:dev -Dquarkus.http.host=0.0.0.0 -Djava.util.logging.manager=org.jboss.logmanager.LogManager -Ddebug=${DEBUG_PORT}'
+      commandLine: './mvnw -Dmaven.repo.local=/home/user/.m2/repository quarkus:dev -Dquarkus.http.host=0.0.0.0 -Ddebug=${DEBUG_PORT}'
       hotReloadCapable: true
       group:
         kind: debug

--- a/stacks/java-quarkus/1.5.0/devfile.yaml
+++ b/stacks/java-quarkus/1.5.0/devfile.yaml
@@ -50,7 +50,7 @@ commands:
   - id: dev-run
     exec:
       component: tools
-      commandLine: './mvnw -Dmaven.repo.local=/home/user/.m2/repository quarkus:dev -Dquarkus.http.host=0.0.0.0 -Djava.util.logging.manager=org.jboss.logmanager.LogManager'
+      commandLine: './mvnw -Dmaven.repo.local=/home/user/.m2/repository quarkus:dev -Dquarkus.http.host=0.0.0.0'
       hotReloadCapable: true
       group:
         kind: run
@@ -59,7 +59,7 @@ commands:
   - id: dev-debug
     exec:
       component: tools
-      commandLine: './mvnw -Dmaven.repo.local=/home/user/.m2/repository quarkus:dev -Dquarkus.http.host=0.0.0.0 -Djava.util.logging.manager=org.jboss.logmanager.LogManager -Ddebug=${DEBUG_PORT}'
+      commandLine: './mvnw -Dmaven.repo.local=/home/user/.m2/repository quarkus:dev -Dquarkus.http.host=0.0.0.0 -Ddebug=${DEBUG_PORT}'
       hotReloadCapable: true
       group:
         kind: debug


### PR DESCRIPTION
fixes devfile/api#1612

it is causing stacktraces:
```
tools: Could not load Logmanager "org.jboss.logmanager.LogManager"
tools: java.lang.ClassNotFoundException: org.jboss.logmanager.LogManager
tools:  at
org.codehaus.plexus.classworlds.strategy.SelfFirstStrategy.loadClass(SelfFirstStrategy.java:42)
```

### What does this PR do?:
_Summarize the changes. Are any stacks or samples added or updated?_

### Which issue(s) this PR fixes:
_Link to github issue(s)_

### PR acceptance criteria:

- [ ] Contributing guide
_Have you read the [devfile registry contributing guide](https://github.com/devfile/registry/blob/main/CONTRIBUTING.md) and followed its instructions?_
- [ ] Test automation
_Does this repository's tests pass with your changes?_
- [ ] Documentation
_Does any documentation need to be updated with your changes?_
- [ ] Check Tools Provider
_Have you tested the changes with existing tools, i.e. Odo, Che, Console? (See [devfile registry contributing guide](https://github.com/devfile/registry/blob/main/CONTRIBUTING.md) on how to test changes)_


### How to test changes / Special notes to the reviewer: