### PR TITLE
Fix lastModified Filter

### DIFF
--- a/.ci/generate_last_mod_file.sh
+++ b/.ci/generate_last_mod_file.sh
@@ -25,8 +25,8 @@ grab_stacks() {
     for filename in $(git ls-tree -r --name-only HEAD); do
         if [[ $filename == *"stacks/"*"/devfile"* ]]; then
             directory=$(dirname "$filename")
-            version=$(yq -r .metadata.name $filename)
-            stack=$(yq -r .metadata.version $filename)
+            stack=$(yq -r .metadata.name $filename)
+            version=$(yq -r .metadata.version $filename)
             # last commit that modified the entire directory that contains a devfile
             last_commit=$(git log -1 --format="%aI" -- "$directory")
 


### PR DESCRIPTION
### What does this PR do?:
_Summarize the changes. Are any stacks or samples added or updated?_
This PR aims to fix the issue described in the linked issue below regarding stacks showing the default Go `time.Time` value. The `stack` and `version` vars in the generation script were flipped, resulting in the parsing from `index/generator` to not be able to find the resulting stacks and issuing the default date as a result.

### Which issue(s) this PR fixes:
_Link to github issue(s)_
fixes https://github.com/devfile/api/issues/1610
### PR acceptance criteria:

- [ ] Contributing guide
_Have you read the [devfile registry contributing guide](https://github.com/devfile/registry/blob/main/CONTRIBUTING.md) and followed its instructions?_
- [ ] Test automation
_Does this repository's tests pass with your changes?_
- [ ] Documentation
_Does any documentation need to be updated with your changes?_
- [ ] Check Tools Provider
_Have you tested the changes with existing tools, i.e. Odo, Che, Console? (See [devfile registry contributing guide](https://github.com/devfile/registry/blob/main/CONTRIBUTING.md) on how to test changes)_


### How to test changes / Special notes to the reviewer:
Run `bash .ci/build.sh` and launch the registry and then hit `/v2index` to see `lastModified` dates are not the default anymore