### PR TITLE
fix description of java-quarkus satck

### DIFF
--- a/stacks/java-quarkus/stack.yaml
+++ b/stacks/java-quarkus/stack.yaml
@@ -1,5 +1,5 @@
 name: java-quarkus
-description: Java application using Quarkus and OpenJDK 17
+description: Java application using Quarkus and OpenJDK 21
 displayName: Quarkus Java
 icon: https://design.jboss.org/quarkus/logo/final/SVG/quarkus_icon_rgb_default.svg
 versions:


### PR DESCRIPTION
### What does this PR do?:
Updates description of java-quarkus stack, because a [default version is 1.5.0](https://github.com/devfile/registry/blob/main/stacks/java-quarkus/stack.yaml#L11) and it uses OpenJDK 21 

### Which issue(s) this PR fixes:
https://github.com/eclipse-che/che/issues/23058

### PR acceptance criteria:

- [ ] Contributing guide
_Have you read the [devfile registry contributing guide](https://github.com/devfile/registry/blob/main/CONTRIBUTING.md) and followed its instructions?_
- [ ] Test automation
_Does this repository's tests pass with your changes?_
- [ ] Documentation
_Does any documentation need to be updated with your changes?_
- [ ] Check Tools Provider
_Have you tested the changes with existing tools, i.e. Odo, Che, Console? (See [devfile registry contributing guide](https://github.com/devfile/registry/blob/main/CONTRIBUTING.md) on how to test changes)_


### How to test changes / Special notes to the reviewer: