### PR TITLE
Update generation script to handle non-versioned items

### DIFF
--- a/.ci/generate_last_mod_file.sh
+++ b/.ci/generate_last_mod_file.sh
@@ -30,6 +30,11 @@ grab_stacks() {
             # last commit that modified the entire directory that contains a devfile
             last_commit=$(git log -1 --format="%aI" -- "$directory")
 
+            # replace null -> undefined for consistency with sample handling
+            if [[ $version == "null" ]]; then
+                version="undefined"
+            fi
+
             stack_data+=("{\"name\": \"${stack}\",\"version\": \"${version}\",\"lastModified\": \"${last_commit}\"}") 
         fi
     done
@@ -48,7 +53,7 @@ grab_samples(){
         version=$(echo "$line" | cut -d ' ' -f 2)
         revision=$(echo "$line" | cut -d ' ' -f 3)
         git_origin=$(echo "$line" | cut -d ' ' -f 4)
-        if [[ $revision == "null" ]]; then
+        if [[ $revision == "undefined" ]]; then
             repo_name="$name"
             git clone -q $git_origin $repo_name
         else
@@ -67,9 +72,9 @@ grab_samples(){
         "\(.name) \(.versions[] | "\(.version) \(.git.revision) \(.git.remotes.origin)")" 
     elif .git.revision != null 
     then 
-        "\(.name) null \(.git.revision) \(.git.remotes.origin)" 
+        "\(.name) undefined \(.git.revision) \(.git.remotes.origin)" 
     else 
-        "\(.name) null null \(.git.remotes.origin)" 
+        "\(.name) undefined undefined \(.git.remotes.origin)" 
     end
     ' $PARENT_DIR/data.json)
 


### PR DESCRIPTION
### What does this PR do?:
_Summarize the changes. Are any stacks or samples added or updated?_

This PR contains the changes required to the `generate_last_mod_file.sh` script to allow for the `last_modified.json` to properly contain stacks/samples that do not have a version. In the case of a non-versioned item the `version` field in the json will be `"null"`.

For samples the parsing handles the following 3 cases:
1. Versioned sample
2. Non-versioned sample that has a git branch preference (revision)
3. Non-versioned sample that has no git branch preference (defaults to main)

Example output:
```
{
  "stacks": [
    {
      "name": "dotnet50",
      "version": "1.0.4",
      "lastModified": "2024-05-14T17:06:30+03:00"
    },
    {
      "name": "dotnet60",
      "version": "1.0.3",
      "lastModified": "2024-07-22T15:33:17+02:00"
    },
    {
      "name": "dotnetcore31",
      "version": "1.0.3",
      "lastModified": "2024-05-27T15:44:32+03:00"
    },
    {
      "name": "go",
      "version": "1.0.2",
      "lastModified": "2023-11-08T12:54:08+00:00"
    },
   ....
  ],
  "samples": [
    {
      "name": "nodejs-basic",
      "version": "3.0.0",
      "lastModified": "2024-06-05T15:26:11-04:00"
    },
    .....
    {
      "name": "test-basic",
      "version": "null",
      "lastModified": "2024-04-18T10:30:44+01:00"
    },
    {
      "name": "test-basic-revision",
      "version": "null",
      "lastModified": "2024-04-18T10:30:44+01:00"
    }
  ]
}


```
### Which issue(s) this PR fixes:
_Link to github issue(s)_

fixes https://github.com/devfile/api/issues/1607

### PR acceptance criteria:

- [ ] Contributing guide
_Have you read the [devfile registry contributing guide](https://github.com/devfile/registry/blob/main/CONTRIBUTING.md) and followed its instructions?_
- [ ] Test automation
_Does this repository's tests pass with your changes?_
- [ ] Documentation
_Does any documentation need to be updated with your changes?_
- [ ] Check Tools Provider
_Have you tested the changes with existing tools, i.e. Odo, Che, Console? (See [devfile registry contributing guide](https://github.com/devfile/registry/blob/main/CONTRIBUTING.md) on how to test changes)_


### How to test changes / Special notes to the reviewer:

To test the changes you will need to do the following:
1. Update `extraDevfileEntries.yaml` locally to contain samples that do not have versions. You can reference the ones I used here:
```
- name: test-basic
    displayName: Basic Python
    description: A simple Hello World application using Python
    icon: https://www.python.org/static/community_logos/python-logo-generic.svg
    tags: ["Python"]
    projectType: python
    language: TEST
    git:
      remotes:
        origin: https://github.com/devfile-samples/devfile-sample-python-basic.git
  - name: test-basic-revision
    displayName: Basic Python
    description: A simple Hello World application using Python
    icon: https://www.python.org/static/community_logos/python-logo-generic.svg
    tags: ["Python"]
    projectType: python
    language: TEST
    git:
      revision: main
      remotes:
        origin: https://github.com/devfile-samples/devfile-sample-python-basic.git
```
2. Create a new stack that has a devfile within it that has no version. In order for this stack to be properly read (since it parses git logs for the changed date) you will need to locally commit the addition of this stack so it appears in the git log.
3. Run `.ci./generate_last_mod_file.sh` and observe the changes in `last_modified.json`.
