### PR TITLE
Deprecate php laravel stack for inactivity

### DIFF
--- a/stacks/php-laravel/1.0.1/devfile.yaml
+++ b/stacks/php-laravel/1.0.1/devfile.yaml
@@ -11,6 +11,7 @@ metadata:
     - PHP
     - Composer
     - Laravel
+    - Deprecated
   projectType: Laravel
   language: PHP
   provider: Red Hat

--- a/stacks/php-laravel/2.0.0/devfile.yaml
+++ b/stacks/php-laravel/2.0.0/devfile.yaml
@@ -11,6 +11,7 @@ metadata:
     - PHP
     - Composer
     - Laravel
+    - Deprecated
   projectType: Laravel
   language: PHP
   provider: Red Hat


### PR DESCRIPTION
### What does this PR do?:
_Summarize the changes. Are any stacks or samples added or updated?_
This PR deprecates `1.0.1` and `2.0.0` stack versions for `php laravel` for inactivity. Both of these stacks had no activity for > 1 year and as per the [lifecycle policy](https://github.com/devfile/registry/blob/main/LIFECYCLE.md#deprecation) we can mark for deprecation. The Devfile team owns this stack as well.

### Which issue(s) this PR fixes:
_Link to github issue(s)_
fixes https://github.com/devfile/api/issues/1459
### PR acceptance criteria:

- [ ] Contributing guide
_Have you read the [devfile registry contributing guide](https://github.com/devfile/registry/blob/main/CONTRIBUTING.md) and followed its instructions?_
- [ ] Test automation
_Does this repository's tests pass with your changes?_
- [ ] Documentation
_Does any documentation need to be updated with your changes?_
- [ ] Check Tools Provider
_Have you tested the changes with existing tools, i.e. Odo, Che, Console? (See [devfile registry contributing guide](https://github.com/devfile/registry/blob/main/CONTRIBUTING.md) on how to test changes)_


### How to test changes / Special notes to the reviewer: