### PR TITLE
Skip ollama stack on nightly run

### DIFF
--- a/tests/check_odov3.sh
+++ b/tests/check_odov3.sh
@@ -54,6 +54,7 @@ ginkgo run --procs 2 \
   --skip="stack: java-openliberty" \
   --skip="stack: java-websphereliberty" \
   --skip="stack: java-quarkus" \
+  --skip="stack: ollama" \
   --slow-spec-threshold 120s \
   --timeout 3h \
   tests/odov3 -- -stacksPath "$(pwd)"/stacks -stackDirs "$stackDirs"


### PR DESCRIPTION
### What does this PR do?:

The ollama stack for the moment gets timeout error on registry nightly run. I'm opening the current PR as a temporary workaround. A permanent fix should be added in this issue: https://github.com/devfile/api/issues/1632

### Which issue(s) this PR fixes:
N/A

### PR acceptance criteria:

- [ ] Contributing guide
_Have you read the [devfile registry contributing guide](https://github.com/devfile/registry/blob/main/CONTRIBUTING.md) and followed its instructions?_
- [ ] Test automation
_Does this repository's tests pass with your changes?_
- [ ] Documentation
_Does any documentation need to be updated with your changes?_
- [ ] Check Tools Provider
_Have you tested the changes with existing tools, i.e. Odo, Che, Console? (See [devfile registry contributing guide](https://github.com/devfile/registry/blob/main/CONTRIBUTING.md) on how to test changes)_


### How to test changes / Special notes to the reviewer: