### PR TITLE
Revert "Revert springboot starterproject update (#476)"

### DIFF
--- a/stacks/java-maven/1.3.0/devfile.yaml
+++ b/stacks/java-maven/1.3.0/devfile.yaml
@@ -14,7 +14,7 @@ starterProjects:
   - name: springbootproject
     git:
       remotes:
-        origin: 'https://github.com/odo-devfiles/springboot-ex.git'
+        origin: 'https://github.com/devfile-samples/springboot-ex.git'
 components:
   - name: tools
     container:

--- a/stacks/java-maven/1.3.1/devfile.yaml
+++ b/stacks/java-maven/1.3.1/devfile.yaml
@@ -14,7 +14,7 @@ starterProjects:
   - name: springbootproject
     git:
       remotes:
-        origin: 'https://github.com/odo-devfiles/springboot-ex.git'
+        origin: 'https://github.com/devfile-samples/springboot-ex.git'
 components:
   - name: tools
     container:

--- a/stacks/java-springboot/1.2.0/devfile.yaml
+++ b/stacks/java-springboot/1.2.0/devfile.yaml
@@ -15,7 +15,7 @@ starterProjects:
   - name: springbootproject
     git:
       remotes:
-        origin: "https://github.com/odo-devfiles/springboot-ex.git"
+        origin: "https://github.com/devfile-samples/springboot-ex.git"
 components:
   - name: tools
     container:

--- a/stacks/java-springboot/1.3.0/devfile.yaml
+++ b/stacks/java-springboot/1.3.0/devfile.yaml
@@ -15,7 +15,7 @@ starterProjects:
   - name: springbootproject
     git:
       remotes:
-        origin: "https://github.com/odo-devfiles/springboot-ex.git"
+        origin: "https://github.com/devfile-samples/springboot-ex.git"
 components:
   - name: tools
     container:

--- a/stacks/java-springboot/1.4.0/devfile.yaml
+++ b/stacks/java-springboot/1.4.0/devfile.yaml
@@ -15,7 +15,7 @@ starterProjects:
   - name: springbootproject
     git:
       remotes:
-        origin: "https://github.com/odo-devfiles/springboot-ex.git"
+        origin: "https://github.com/devfile-samples/springboot-ex.git"
 components:
   - name: tools
     container:

--- a/stacks/java-springboot/2.0.0/devfile.yaml
+++ b/stacks/java-springboot/2.0.0/devfile.yaml
@@ -15,7 +15,7 @@ starterProjects:
   - name: springbootproject
     git:
       remotes:
-        origin: "https://github.com/odo-devfiles/springboot-ex.git"
+        origin: "https://github.com/devfile-samples/springboot-ex.git"
 components:
   - name: tools
     container:

--- a/stacks/java-springboot/2.1.0/devfile.yaml
+++ b/stacks/java-springboot/2.1.0/devfile.yaml
@@ -15,7 +15,7 @@ starterProjects:
   - name: springbootproject
     git:
       remotes:
-        origin: "https://github.com/odo-devfiles/springboot-ex.git"
+        origin: "https://github.com/devfile-samples/springboot-ex.git"
 components:
   - name: tools
     container:

--- a/stacks/java-springboot/2.2.0/devfile.yaml
+++ b/stacks/java-springboot/2.2.0/devfile.yaml
@@ -15,7 +15,7 @@ starterProjects:
   - name: springbootproject
     git:
       remotes:
-        origin: "https://github.com/odo-devfiles/springboot-ex.git"
+        origin: "https://github.com/devfile-samples/springboot-ex.git"
 components:
   - name: tools
     container:


### PR DESCRIPTION
# Description of Changes

This PR reverts the commit a55e8501a70dd97e2e4895de19f2732df8194c42. The commit was originally merged in attempt to fix https://github.com/devfile/api/issues/1628. As the issue still occurs post merge might be good to revert the updates and keep using the `devfile-sample-java-springboot` as the starter project.

# Related Issue(s)
N/A

# Acceptance Criteria
<!-- _Check the relevant boxes below_ -->
- [ ] Contributing guide

_Have you read the [devfile registry contributing guide](https://github.com/devfile/registry/blob/main/CONTRIBUTING.md) and followed its instructions?_
- [ ] Test automation

_Does this repository's tests pass with your changes?_
- [ ] Documentation

_Does any documentation need to be updated with your changes?_
- [ ] Check Tools Provider

_Have you tested the changes with existing tools, i.e. Odo, Che, Console? (See [devfile registry contributing guide](https://github.com/devfile/registry/blob/main/CONTRIBUTING.md) on how to test changes)_


# Tests Performed
_Explain what tests you personally ran to ensure the changes are functioning as expected._

# How To Test
_Instructions for the reviewer on how to test your changes._

# Notes To Reviewer
_Any notes you would like to include for the reviewer._