### PR TITLE
Revert "Use latest Java Spring Boot stack as default (#439)"

### DIFF
--- a/stacks/java-springboot/stack.yaml
+++ b/stacks/java-springboot/stack.yaml
@@ -7,8 +7,8 @@ versions:
   # 1.3.0, 1.4.0: with JDK 17
   - version: 1.3.0
   - version: 1.4.0
+    default: true # should have one and only one default version
   - version: 2.0.0
   # 2.1.0, 2.2.0: with JDK 17
   - version: 2.1.0
   - version: 2.2.0
-    default: true # should have one and only one default version


### PR DESCRIPTION
This reverts commit 0513d066ac5f48a0729cd7fe330222df6a4fa2bd.

# Description of Changes
Temporary fix by reverting the update of the default version for the springboot stack. The reasoning is shared here: https://github.com/devfile/api/issues/1628#issuecomment-2329776908

# Related Issue(s)
Fixes https://github.com/devfile/api/issues/1628

# Acceptance Criteria
<!-- _Check the relevant boxes below_ -->
- [ ] Contributing guide

_Have you read the [devfile registry contributing guide](https://github.com/devfile/registry/blob/main/CONTRIBUTING.md) and followed its instructions?_
- [ ] Test automation

_Does this repository's tests pass with your changes?_
- [ ] Documentation

_Does any documentation need to be updated with your changes?_
- [ ] Check Tools Provider

_Have you tested the changes with existing tools, i.e. Odo, Che, Console? (See [devfile registry contributing guide](https://github.com/devfile/registry/blob/main/CONTRIBUTING.md) on how to test changes)_


# Tests Performed
_Explain what tests you personally ran to ensure the changes are functioning as expected._

# How To Test
_Instructions for the reviewer on how to test your changes._

# Notes To Reviewer
_Any notes you would like to include for the reviewer._