### PR TITLE
Add separate registry viewer tag parameter to OpenShift deployment template

### DIFF
--- a/.ci/deploy/devfile-registry.yaml
+++ b/.ci/deploy/devfile-registry.yaml
@@ -1,17 +1,17 @@
 #
-#   Copyright 2021-2023 Red Hat, Inc.
+# Copyright Red Hat
 #
-#   Licensed under the Apache License, Version 2.0 (the "License");
-#   you may not use this file except in compliance with the License.
-#   You may obtain a copy of the License at
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
 #
-#      http://www.apache.org/licenses/LICENSE-2.0
+#     http://www.apache.org/licenses/LICENSE-2.0
 #
-#   Unless required by applicable law or agreed to in writing, software
-#   distributed under the License is distributed on an "AS IS" BASIS,
-#   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-#   See the License for the specific language governing permissions and
-#   limitations under the License.
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
 ---
 apiVersion: template.openshift.io/v1
 kind: Template
@@ -106,7 +106,7 @@ objects:
               value: ${REGISTRY_NAME}
             - name: TELEMETRY_KEY
               value: ${TELEMETRY_KEY}
-        - image: ${REGISTRY_VIEWER_IMAGE}:${IMAGE_TAG}
+        - image: ${REGISTRY_VIEWER_IMAGE}:${REGISTRY_VIEWER_IMAGE_TAG}
           imagePullPolicy: "${REGISTRY_VIEWER_PULL_POLICY}"
           name: devfile-registry-viewer
           securityContext:
@@ -252,10 +252,6 @@ parameters:
   value: quay.io/devfile/devfile-index
   displayName: Devfile registry index image
   description: Devfile registry index docker image. Defaults to quay.io/devfile/devfile-index
-- name: REGISTRY_VIEWER_IMAGE
-  value: quay.io/devfile/registry-viewer
-  displayName: Devfile registry viewer image
-  description: Devfile registry viewer docker image. Defaults to quay.io/devfile/registry-viewer
 - name: IMAGE_TAG
   value: next
   displayName: Devfile registry version
@@ -268,6 +264,14 @@ parameters:
   value: Always
   displayName: Devfile registry image pull policy
   description: Always pull by default. Can be IfNotPresent
+- name: REGISTRY_VIEWER_IMAGE
+  value: quay.io/devfile/registry-viewer
+  displayName: Devfile registry viewer image
+  description: Devfile registry viewer docker image. Defaults to quay.io/devfile/registry-viewer
+- name: REGISTRY_VIEWER_IMAGE_TAG
+  value: next
+  displayName: Devfile registry viewer version
+  description: Devfile registry viewer version which defaults to next
 - name: REGISTRY_VIEWER_MEMORY_LIMIT
   value: 256Mi
   displayName: Memory Limit


### PR DESCRIPTION
# Description of Changes
_Summarize the changes you made as part of this pull request._

Use a separate parameter to use a different tag for the registry-viewer component.

# Related Issue(s)
_Link the GitHub/GitLab/JIRA issues that are related to this PR._

Part of https://github.com/devfile/api/issues/1657

# Acceptance Criteria
<!-- _Check the relevant boxes below_ -->
- [ ] Contributing guide

_Have you read the [devfile registry contributing guide](https://github.com/devfile/registry/blob/main/CONTRIBUTING.md) and followed its instructions?_
- [ ] Test automation

_Does this repository's tests pass with your changes?_
- [ ] Documentation

_Does any documentation need to be updated with your changes?_
- [ ] Check Tools Provider

_Have you tested the changes with existing tools, i.e. Odo, Che, Console? (See [devfile registry contributing guide](https://github.com/devfile/registry/blob/main/CONTRIBUTING.md) on how to test changes)_


# Tests Performed
_Explain what tests you personally ran to ensure the changes are functioning as expected._

# How To Test
_Instructions for the reviewer on how to test your changes._

Use `oc process -f .ci/deploy/devfile-registry.yaml -p REGISTRY_VIEWER_IMAGE=<registry-viewer-image> -p REGISTRY_VIEWER_IMAGE_TAG=<registry-viewer-image-tag> | oc apply -f -` on a target OpenShift cluster.

This should produce a devfile registry deployment where the given `REGISTRY_VIEWER_IMAGE_TAG` is used instead of the previous `IMAGE_TAG` that was shared with and still used for `devfile-index` image.

# Notes To Reviewer
_Any notes you would like to include for the reviewer._