### PR TITLE
Fix PR integration testing

### DIFF
--- a/.ci/openshift_integration.sh
+++ b/.ci/openshift_integration.sh
@@ -30,6 +30,9 @@ export ODO_DISABLE_TELEMETRY=true
 # Set yq version
 YQ_VERSION=${YQ_VERSION:-v4.44.1}
 
+# Set odo version
+ODO_VERSION=${ODO_VERSION:-v3.16.1}
+
 # Split the registry image and image tag from the REGISTRY_IMAGE env variable
 IMG="$(echo $REGISTRY_IMAGE | cut -d':' -f1)"
 TAG="$(echo $REGISTRY_IMAGE | cut -d':' -f2)"
@@ -42,7 +45,7 @@ curl -sL https://github.com/mikefarah/yq/releases/download/${YQ_VERSION}/yq_linu
 YQ_PATH=$(realpath yq)
 
 # Download odo
-curl -sL https://developers.redhat.com/content-gateway/rest/mirror/pub/openshift-v4/clients/odo/v2.5.1/odo-linux-amd64 -o odo && chmod +x odo
+curl -sL https://developers.redhat.com/content-gateway/rest/mirror/pub/openshift-v4/clients/odo/${ODO_VERSION}/odo-linux-amd64 -o odo && chmod +x odo
 export GLOBALODOCONFIG=$(pwd)/preferences.yaml
 
 # Install the devfile registry
@@ -65,8 +68,8 @@ REGISTRY_HOSTNAME=$(oc get route devfile-registry -o jsonpath="{.spec.host}")
 echo $REGISTRY_HOSTNAME
 
 # Delete the default devfile registry and add the test one we just stood up
-$(realpath odo) registry delete DefaultDevfileRegistry -f
-$(realpath odo) registry add TestDevfileRegistry http://$REGISTRY_HOSTNAME
+$(realpath odo) preference remove registry DefaultDevfileRegistry -f
+$(realpath odo) preference add registry TestDevfileRegistry http://$REGISTRY_HOSTNAME
 
 # Run the devfile validation tests
-ENV=openshift REGISTRY=remote ENABLE_TLS="false" tests/check_odov2.sh $(realpath odo) $YQ_PATH
+ENV=openshift REGISTRY=remote tests/check_odov3.sh $(realpath odo) $YQ_PATH

--- a/.ci/openshift_integration.sh
+++ b/.ci/openshift_integration.sh
@@ -24,6 +24,8 @@ set -u
 # print each command before executing it
 set -x
 
+BASE_DIR="$(realpath $(dirname ${BASH_SOURCE[0]})/..)"
+
 # Disable telemtry for odo
 export ODO_DISABLE_TELEMETRY=true
 
@@ -47,6 +49,10 @@ YQ_PATH=$(realpath yq)
 # Download odo
 curl -sL https://developers.redhat.com/content-gateway/rest/mirror/pub/openshift-v4/clients/odo/${ODO_VERSION}/odo-linux-amd64 -o odo && chmod +x odo
 export GLOBALODOCONFIG=$(pwd)/preferences.yaml
+
+# Download & Install Ginkgo
+GINKGO_VERSION="$(cd $BASE_DIR/tests/odov3 && go list -m -json all | ${YQ_PATH} 'select(.Path == "github.com/onsi/ginkgo/v2") | .Version' -Mr -p=json)"
+go install github.com/onsi/ginkgo/v2/ginkgo@${GINKGO_VERSION}
 
 # Install the devfile registry
 oc process -f .ci/deploy/devfile-registry.yaml -p DEVFILE_INDEX_IMAGE=$IMG -p IMAGE_TAG=$TAG -p REPLICAS=3 -p ANALYTICS_WRITE_KEY= | \

--- a/.ci/openshift_integration.sh
+++ b/.ci/openshift_integration.sh
@@ -78,4 +78,4 @@ $(realpath odo) preference remove registry DefaultDevfileRegistry -f
 $(realpath odo) preference add registry TestDevfileRegistry http://$REGISTRY_HOSTNAME
 
 # Run the devfile validation tests
-ENV=openshift REGISTRY=remote tests/check_odov3.sh $(realpath odo) $YQ_PATH
+ENV=openshift REGISTRY=remote ENABLE_TLS_VERIFY="false" $BASE_DIR/tests/check_odov3.sh $(realpath odo)

--- a/.ci/openshift_integration.sh
+++ b/.ci/openshift_integration.sh
@@ -55,11 +55,11 @@ GINKGO_VERSION="$(cd $BASE_DIR/tests/odov3 && go list -m -json all | ${YQ_PATH} 
 go install github.com/onsi/ginkgo/v2/ginkgo@${GINKGO_VERSION}
 
 # Install the devfile registry
-oc process -f .ci/deploy/devfile-registry.yaml -p DEVFILE_INDEX_IMAGE=$IMG -p IMAGE_TAG=$TAG -p REPLICAS=3 -p ANALYTICS_WRITE_KEY= | \
+oc process -f $BASE_DIR/.ci/deploy/devfile-registry.yaml -p DEVFILE_INDEX_IMAGE=$IMG -p IMAGE_TAG=$TAG -p REPLICAS=3 -p ANALYTICS_WRITE_KEY= | \
   oc apply -f -
 
 # Deploy the routes for the registry
-oc process -f .ci/deploy/route.yaml | oc apply -f -
+oc process -f $BASE_DIR/.ci/deploy/route.yaml | oc apply -f -
 
 # Wait for the registry to become ready
 oc wait deploy/devfile-registry --for=condition=Available --timeout=600s

--- a/.ci/openshift_integration.sh
+++ b/.ci/openshift_integration.sh
@@ -1,18 +1,18 @@
 #!/bin/bash
+
+# Copyright Red Hat
 #
-#   Copyright 2021-2022 Red Hat, Inc.
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
 #
-#   Licensed under the Apache License, Version 2.0 (the "License");
-#   you may not use this file except in compliance with the License.
-#   You may obtain a copy of the License at
+#     http://www.apache.org/licenses/LICENSE-2.0
 #
-#      http://www.apache.org/licenses/LICENSE-2.0
-#
-#   Unless required by applicable law or agreed to in writing, software
-#   distributed under the License is distributed on an "AS IS" BASIS,
-#   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-#   See the License for the specific language governing permissions and
-#   limitations under the License.
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
 
 #!/usr/bin/env bash
 # exit immediately when a command fails
@@ -69,4 +69,4 @@ $(realpath odo) registry delete DefaultDevfileRegistry -f
 $(realpath odo) registry add TestDevfileRegistry http://$REGISTRY_HOSTNAME
 
 # Run the devfile validation tests
-ENV=openshift REGISTRY=remote tests/check_odov2.sh $(realpath odo) $YQ_PATH
+ENV=openshift REGISTRY=remote ENABLE_TLS="false" tests/check_odov2.sh $(realpath odo) $YQ_PATH

--- a/.ci/openshift_integration.sh
+++ b/.ci/openshift_integration.sh
@@ -78,4 +78,4 @@ $(realpath odo) preference remove registry DefaultDevfileRegistry -f
 $(realpath odo) preference add registry TestDevfileRegistry http://$REGISTRY_HOSTNAME
 
 # Run the devfile validation tests
-ENV=openshift REGISTRY=remote ENABLE_TLS_VERIFY="false" $BASE_DIR/tests/check_odov3.sh $(realpath odo)
+ENV=openshift REGISTRY=remote $BASE_DIR/tests/check_odov3.sh $(realpath odo)

--- a/tests/check_odov2.sh
+++ b/tests/check_odov2.sh
@@ -1,8 +1,24 @@
 #!/usr/bin/env bash
 
+#
+# Copyright Red Hat
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 set -x
 DEVFILES_DIR="$(pwd)/stacks"
 FAILED_TESTS=()
+ENABLE_TLS=${ENABLE_TLS:-"true"}
 
 # The stacks to test as a string separated by spaces
 STACKS=$(bash "$(pwd)/tests/get_stacks.sh")
@@ -42,7 +58,16 @@ waitForHTTPStatus() {
 
   for i in $(seq 1 10); do
     echo "try: $i"
-    content=$(curl -i "$url")
+    if [[ $ENABLE_TLS == "true" ]]
+    then
+      content=$(curl -i "$url")
+    elif [[ $ENABLE_TLS == "false" ]]
+    then
+      content=$(curl -i --insecure "$url")
+    else
+      echo "ERROR: ENABLE_TLS must be either true or false"
+      return 1
+    fi
     echo "Checking if $url is returning HTTP $status_code"
     echo "$content" | grep -q -E "HTTP/[0-9.]+ $status_code"
     ret_val=$?

--- a/tests/check_odov2.sh
+++ b/tests/check_odov2.sh
@@ -18,7 +18,7 @@
 set -x
 DEVFILES_DIR="$(pwd)/stacks"
 FAILED_TESTS=()
-ENABLE_TLS=${ENABLE_TLS:-"true"}
+ENABLE_TLS_VERIFY=${ENABLE_TLS_VERIFY:-"true"}
 
 # The stacks to test as a string separated by spaces
 STACKS=$(bash "$(pwd)/tests/get_stacks.sh")
@@ -58,10 +58,10 @@ waitForHTTPStatus() {
 
   for i in $(seq 1 10); do
     echo "try: $i"
-    if [[ $ENABLE_TLS == "true" ]]
+    if [[ $ENABLE_TLS_VERIFY == "true" ]]
     then
       content=$(curl -i "$url")
-    elif [[ $ENABLE_TLS == "false" ]]
+    elif [[ $ENABLE_TLS_VERIFY == "false" ]]
     then
       content=$(curl -i --insecure "$url")
     else

--- a/tests/check_odov3.sh
+++ b/tests/check_odov3.sh
@@ -3,6 +3,11 @@
 set -x
 
 stackDirs=$(bash "$(pwd)/tests/get_stacks.sh")
+args=""
+
+if [ ! -z "${1}" ]; then
+  args="-odoPath ${1} ${args}"
+fi
 
 ginkgo run --procs 2 \
   --skip="stack: java-openliberty-gradle version: 0.4.0 starter: rest" \
@@ -58,4 +63,4 @@ ginkgo run --procs 2 \
   --skip="stack: ollama" \
   --slow-spec-threshold 120s \
   --timeout 3h \
-  tests/odov3 -- -stacksPath "$(pwd)"/stacks -stackDirs "$stackDirs"
+  tests/odov3 -- -stacksPath "$(pwd)"/stacks -stackDirs "$stackDirs" ${args}

--- a/tests/odov3/odo_test.go
+++ b/tests/odov3/odo_test.go
@@ -10,6 +10,9 @@ ginkgo run --focus "stack: java-vertx starter: vertx-http-example"  -- -stacksPa
 
 test all starter project in a specific stack:
 ginkgo run --focus "stack: java-vertx"  -- -stacksPath ../../stacks
+
+specifying odo path:
+ginkgo run -v  -- -odoPath <path/to/odo/binary>
 */
 
 package main
@@ -37,10 +40,12 @@ import (
 
 var stacksPath string
 var stackDirs string
+var odoPath string
 
 func init() {
 	flag.StringVar(&stacksPath, "stacksPath", "../../stacks", "The path to the directory containing the stacks")
 	flag.StringVar(&stackDirs, "stackDirs", "", "The stacks to test as a string separated by spaces")
+	flag.StringVar(&odoPath, "odoPath", "odo", "The path to the odo binary, defaults to path symbol")
 }
 
 // all stacks to be tested
@@ -404,7 +409,7 @@ func runOdoDev(additionalArgs ...string) (io.ReadCloser, io.ReadCloser, *exec.Cm
 	args := []string{"dev", "--random-ports"}
 	args = append(args, additionalArgs...)
 	GinkgoWriter.Println("Executing odo " + strings.Join(args, " "))
-	cmd := exec.Command("odo", args...)
+	cmd := exec.Command(odoPath, args...)
 
 	stdout, err := cmd.StdoutPipe()
 	if err != nil {
@@ -426,8 +431,11 @@ func runOdoDev(additionalArgs ...string) (io.ReadCloser, io.ReadCloser, *exec.Cm
 // run odo commands
 // returns stdout, stderr, and error
 func runOdo(args ...string) ([]byte, []byte, error) {
-	GinkgoWriter.Println("Executing: odo", strings.Join(args, " "))
-	cmd := exec.Command("odo", args...)
+	// Clean given path
+	filepath.Clean(odoPath)
+
+	GinkgoWriter.Printf("Executing: %s %s\n", odoPath, strings.Join(args, " "))
+	cmd := exec.Command(odoPath, args...)
 
 	stdout, err := cmd.StdoutPipe()
 	if err != nil {

--- a/tests/odov3/odo_test.go
+++ b/tests/odov3/odo_test.go
@@ -434,7 +434,7 @@ func runOdo(args ...string) ([]byte, []byte, error) {
 	// Clean given path
 	filepath.Clean(odoPath)
 
-	GinkgoWriter.Printf("Executing: %s %s\n", odoPath, strings.Join(args, " "))
+	GinkgoWriter.Println("Executing: odo", strings.Join(args, " "))
 	cmd := exec.Command(odoPath, args...)
 
 	stdout, err := cmd.StdoutPipe()


### PR DESCRIPTION
# Description of Changes
_Summarize the changes you made as part of this pull request._

To fix the current unexpected integration testing failures this PR changes include the following:
- Adds TLS verification enablement feature for the odo test scripts and openshift integration test script. This is to address the failing PR integration testing check due to the self signed cert not being accepted by `curl` when testing stacks using HTTPS rather than HTTP.
- Migrates integration test script to use the odo v3 test script instead of odo v2 test script. This resolves failures due to some of the community stacks using newer schema versions for the default stack versions than what the odo v2 client supports.

# Related Issue(s)
_Link the GitHub/GitLab/JIRA issues that are related to this PR._

fixes devfile/api#1663
fixes devfile/api#1664

# Acceptance Criteria
<!-- _Check the relevant boxes below_ -->
- [ ] Contributing guide

_Have you read the [devfile registry contributing guide](https://github.com/devfile/registry/blob/main/CONTRIBUTING.md) and followed its instructions?_
- [ ] Test automation

_Does this repository's tests pass with your changes?_
- [ ] Documentation

_Does any documentation need to be updated with your changes?_
- [ ] Check Tools Provider

_Have you tested the changes with existing tools, i.e. Odo, Che, Console? (See [devfile registry contributing guide](https://github.com/devfile/registry/blob/main/CONTRIBUTING.md) on how to test changes)_


# Tests Performed
_Explain what tests you personally ran to ensure the changes are functioning as expected._

# How To Test
_Instructions for the reviewer on how to test your changes._

1. Connect to an OpenShift cluster using a self signed cert
2. Run `bash .ci/openshift_integration.sh`

# Notes To Reviewer
_Any notes you would like to include for the reviewer._