### PR TITLE
update: migrate jhipster online to red hat developer demo

### DIFF
--- a/.ci/openshift_integration.sh
+++ b/.ci/openshift_integration.sh
@@ -1,18 +1,18 @@
 #!/bin/bash
+
+# Copyright Red Hat
 #
-#   Copyright 2021-2022 Red Hat, Inc.
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
 #
-#   Licensed under the Apache License, Version 2.0 (the "License");
-#   you may not use this file except in compliance with the License.
-#   You may obtain a copy of the License at
+#     http://www.apache.org/licenses/LICENSE-2.0
 #
-#      http://www.apache.org/licenses/LICENSE-2.0
-#
-#   Unless required by applicable law or agreed to in writing, software
-#   distributed under the License is distributed on an "AS IS" BASIS,
-#   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-#   See the License for the specific language governing permissions and
-#   limitations under the License.
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
 
 #!/usr/bin/env bash
 # exit immediately when a command fails
@@ -24,11 +24,16 @@ set -u
 # print each command before executing it
 set -x
 
+BASE_DIR="$(realpath $(dirname ${BASH_SOURCE[0]})/..)"
+
 # Disable telemtry for odo
 export ODO_DISABLE_TELEMETRY=true
 
 # Set yq version
 YQ_VERSION=${YQ_VERSION:-v4.44.1}
+
+# Set odo version
+ODO_VERSION=${ODO_VERSION:-v3.16.1}
 
 # Split the registry image and image tag from the REGISTRY_IMAGE env variable
 IMG="$(echo $REGISTRY_IMAGE | cut -d':' -f1)"
@@ -42,15 +47,19 @@ curl -sL https://github.com/mikefarah/yq/releases/download/${YQ_VERSION}/yq_linu
 YQ_PATH=$(realpath yq)
 
 # Download odo
-curl -sL https://developers.redhat.com/content-gateway/rest/mirror/pub/openshift-v4/clients/odo/v2.5.1/odo-linux-amd64 -o odo && chmod +x odo
+curl -sL https://developers.redhat.com/content-gateway/rest/mirror/pub/openshift-v4/clients/odo/${ODO_VERSION}/odo-linux-amd64 -o odo && chmod +x odo
 export GLOBALODOCONFIG=$(pwd)/preferences.yaml
 
+# Download & Install Ginkgo
+GINKGO_VERSION="$(cd $BASE_DIR/tests/odov3 && go list -m -json all | ${YQ_PATH} 'select(.Path == "github.com/onsi/ginkgo/v2") | .Version' -Mr -p=json)"
+go install github.com/onsi/ginkgo/v2/ginkgo@${GINKGO_VERSION}
+
 # Install the devfile registry
-oc process -f .ci/deploy/devfile-registry.yaml -p DEVFILE_INDEX_IMAGE=$IMG -p IMAGE_TAG=$TAG -p REPLICAS=3 -p ANALYTICS_WRITE_KEY= | \
+oc process -f $BASE_DIR/.ci/deploy/devfile-registry.yaml -p DEVFILE_INDEX_IMAGE=$IMG -p IMAGE_TAG=$TAG -p REPLICAS=3 -p ANALYTICS_WRITE_KEY= | \
   oc apply -f -
 
 # Deploy the routes for the registry
-oc process -f .ci/deploy/route.yaml | oc apply -f -
+oc process -f $BASE_DIR/.ci/deploy/route.yaml | oc apply -f -
 
 # Wait for the registry to become ready
 oc wait deploy/devfile-registry --for=condition=Available --timeout=600s
@@ -65,8 +74,8 @@ REGISTRY_HOSTNAME=$(oc get route devfile-registry -o jsonpath="{.spec.host}")
 echo $REGISTRY_HOSTNAME
 
 # Delete the default devfile registry and add the test one we just stood up
-$(realpath odo) registry delete DefaultDevfileRegistry -f
-$(realpath odo) registry add TestDevfileRegistry http://$REGISTRY_HOSTNAME
+$(realpath odo) preference remove registry DefaultDevfileRegistry -f
+$(realpath odo) preference add registry TestDevfileRegistry http://$REGISTRY_HOSTNAME
 
 # Run the devfile validation tests
-ENV=openshift REGISTRY=remote tests/check_odov2.sh $(realpath odo) $YQ_PATH
+ENV=openshift REGISTRY=remote $BASE_DIR/tests/check_odov3.sh $(realpath odo)

--- a/.tekton/devfile-registry-main-pull-request.yaml
+++ b/.tekton/devfile-registry-main-pull-request.yaml
@@ -156,7 +156,7 @@ spec:
         - name: name
           value: init
         - name: bundle
-          value: quay.io/konflux-ci/tekton-catalog/task-init:0.2@sha256:0523b51c28375a3f222da91690e22eff11888ebc98a0c73c468af44762265c69
+          value: quay.io/konflux-ci/tekton-catalog/task-init:0.2@sha256:90dda596d44b3f861889da2fba161dff34c6116fe76c3989e3f84262ea0f29cd
         - name: kind
           value: task
         resolver: bundles
@@ -198,7 +198,7 @@ spec:
         - name: name
           value: prefetch-dependencies
         - name: bundle
-          value: quay.io/konflux-ci/tekton-catalog/task-prefetch-dependencies:0.1@sha256:d3d8a8bfee292afee3c683692fdd70c031ef430446124285f6abc73365839a6f
+          value: quay.io/konflux-ci/tekton-catalog/task-prefetch-dependencies:0.2@sha256:b7a6b67e97c6c03b552b9cd57d4a2868d63e279ee68ced2a53e713befca9e009
         - name: kind
           value: task
         resolver: bundles
@@ -242,7 +242,7 @@ spec:
         - name: name
           value: buildah
         - name: bundle
-          value: quay.io/konflux-ci/tekton-catalog/task-buildah:0.2@sha256:aebfe04c80f7fd937628fad760c095c6a0efacb048f2c98e5d5e7f2b0f134cf9
+          value: quay.io/konflux-ci/tekton-catalog/task-buildah:0.2@sha256:03ff951f641678ae63e7d7f956a30a52547a58e093970a0a88665a6238c5061b
         - name: kind
           value: task
         resolver: bundles
@@ -463,7 +463,7 @@ spec:
         - name: name
           value: coverity-availability-check
         - name: bundle
-          value: quay.io/konflux-ci/tekton-catalog/task-coverity-availability-check:0.1@sha256:dfe1150a94c7464c4a1e0b5a2bfdab4c9c97f51a992f8a479a43acc64ffcbf73
+          value: quay.io/konflux-ci/tekton-catalog/task-coverity-availability-check:0.1@sha256:8e16d7d762c4d078740583c010195f506c3db1595979cbd05aadf917724e4558
         - name: kind
           value: task
         resolver: bundles
@@ -575,7 +575,7 @@ spec:
         - name: name
           value: rpms-signature-scan
         - name: bundle
-          value: quay.io/konflux-ci/tekton-catalog/task-rpms-signature-scan:0.2@sha256:8f3b23bf1b0ef55cc79d28604d2397a0101ac9c0c42ae26e26532eb2778c801b
+          value: quay.io/konflux-ci/tekton-catalog/task-rpms-signature-scan:0.2@sha256:39cd56ffa26ff5edfd5bf9b61e902cae35a345c078cd9dcbc0737d30f3ce5ef1
         - name: kind
           value: task
         resolver: bundles

--- a/.tekton/devfile-registry-main-push.yaml
+++ b/.tekton/devfile-registry-main-push.yaml
@@ -153,7 +153,7 @@ spec:
         - name: name
           value: init
         - name: bundle
-          value: quay.io/konflux-ci/tekton-catalog/task-init:0.2@sha256:0523b51c28375a3f222da91690e22eff11888ebc98a0c73c468af44762265c69
+          value: quay.io/konflux-ci/tekton-catalog/task-init:0.2@sha256:90dda596d44b3f861889da2fba161dff34c6116fe76c3989e3f84262ea0f29cd
         - name: kind
           value: task
         resolver: bundles
@@ -195,7 +195,7 @@ spec:
         - name: name
           value: prefetch-dependencies
         - name: bundle
-          value: quay.io/konflux-ci/tekton-catalog/task-prefetch-dependencies:0.1@sha256:d3d8a8bfee292afee3c683692fdd70c031ef430446124285f6abc73365839a6f
+          value: quay.io/konflux-ci/tekton-catalog/task-prefetch-dependencies:0.2@sha256:b7a6b67e97c6c03b552b9cd57d4a2868d63e279ee68ced2a53e713befca9e009
         - name: kind
           value: task
         resolver: bundles
@@ -239,7 +239,7 @@ spec:
         - name: name
           value: buildah
         - name: bundle
-          value: quay.io/konflux-ci/tekton-catalog/task-buildah:0.2@sha256:aebfe04c80f7fd937628fad760c095c6a0efacb048f2c98e5d5e7f2b0f134cf9
+          value: quay.io/konflux-ci/tekton-catalog/task-buildah:0.2@sha256:03ff951f641678ae63e7d7f956a30a52547a58e093970a0a88665a6238c5061b
         - name: kind
           value: task
         resolver: bundles
@@ -460,7 +460,7 @@ spec:
         - name: name
           value: coverity-availability-check
         - name: bundle
-          value: quay.io/konflux-ci/tekton-catalog/task-coverity-availability-check:0.1@sha256:dfe1150a94c7464c4a1e0b5a2bfdab4c9c97f51a992f8a479a43acc64ffcbf73
+          value: quay.io/konflux-ci/tekton-catalog/task-coverity-availability-check:0.1@sha256:8e16d7d762c4d078740583c010195f506c3db1595979cbd05aadf917724e4558
         - name: kind
           value: task
         resolver: bundles
@@ -575,7 +575,7 @@ spec:
         - name: name
           value: rpms-signature-scan
         - name: bundle
-          value: quay.io/konflux-ci/tekton-catalog/task-rpms-signature-scan:0.2@sha256:8f3b23bf1b0ef55cc79d28604d2397a0101ac9c0c42ae26e26532eb2778c801b
+          value: quay.io/konflux-ci/tekton-catalog/task-rpms-signature-scan:0.2@sha256:39cd56ffa26ff5edfd5bf9b61e902cae35a345c078cd9dcbc0737d30f3ce5ef1
         - name: kind
           value: task
         resolver: bundles

--- a/stacks/jhipster-online/2.33.0/devfile.yaml
+++ b/stacks/jhipster-online/2.33.0/devfile.yaml
@@ -3,7 +3,7 @@ metadata:
   name: jhipster-online
   description: Stack with JHipster Online on Red Hat OpenShift Dev Spaces
   displayName: JHipster Online
-  icon: https://raw.githubusercontent.com/maximilianoPizarro/ecommerce-oracle/main/jhipster-icon.png
+  icon: https://raw.githubusercontent.com/redhat-developer-demos/jhipster-online/main/jhipster-icon.png
   website: https://start.jhipster.tech
   tags:
     - Java
@@ -17,13 +17,13 @@ projects:
   - name: jhipster-online
     git:
       remotes:
-        origin: 'https://github.com/maximilianoPizarro/jhipster-online'
+        origin: 'https://github.com/redhat-developer-demos/jhipster-online'
       checkoutFrom:
-        revision: openshift
+        revision: main
 components:
   - name: tools
     container:
-      image: 'quay.io/maximilianopizarro/jhipster-devspace@sha256:c27aefcf6ce158479bafae63758c1f0993c430a6ee15f76cf369fc889e54eae5'
+      image: 'quay.io/devfile/jhipster-online@sha256:254c710006b1582b2ebc48cc74ae080a9e10caa99dc1b62c1adb3341f072aede'
       mountSources: true
       cpuLimit: '4'
       cpuRequest: '1'

--- a/tests/check_odov2.sh
+++ b/tests/check_odov2.sh
@@ -1,8 +1,24 @@
 #!/usr/bin/env bash
 
+#
+# Copyright Red Hat
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 set -x
 DEVFILES_DIR="$(pwd)/stacks"
 FAILED_TESTS=()
+ENABLE_TLS_VERIFY=${ENABLE_TLS_VERIFY:-"true"}
 
 # The stacks to test as a string separated by spaces
 STACKS=$(bash "$(pwd)/tests/get_stacks.sh")
@@ -42,7 +58,16 @@ waitForHTTPStatus() {
 
   for i in $(seq 1 10); do
     echo "try: $i"
-    content=$(curl -i "$url")
+    if [[ $ENABLE_TLS_VERIFY == "true" ]]
+    then
+      content=$(curl -i "$url")
+    elif [[ $ENABLE_TLS_VERIFY == "false" ]]
+    then
+      content=$(curl -i --insecure "$url")
+    else
+      echo "ERROR: ENABLE_TLS must be either true or false"
+      return 1
+    fi
     echo "Checking if $url is returning HTTP $status_code"
     echo "$content" | grep -q -E "HTTP/[0-9.]+ $status_code"
     ret_val=$?

--- a/tests/check_odov3.sh
+++ b/tests/check_odov3.sh
@@ -3,6 +3,11 @@
 set -x
 
 stackDirs=$(bash "$(pwd)/tests/get_stacks.sh")
+args=""
+
+if [ ! -z "${1}" ]; then
+  args="-odoPath ${1} ${args}"
+fi
 
 ginkgo run --procs 2 \
   --skip="stack: java-openliberty-gradle version: 0.4.0 starter: rest" \
@@ -58,4 +63,4 @@ ginkgo run --procs 2 \
   --skip="stack: ollama" \
   --slow-spec-threshold 120s \
   --timeout 3h \
-  tests/odov3 -- -stacksPath "$(pwd)"/stacks -stackDirs "$stackDirs"
+  tests/odov3 -- -stacksPath "$(pwd)"/stacks -stackDirs "$stackDirs" ${args}

--- a/tests/odov3/odo_test.go
+++ b/tests/odov3/odo_test.go
@@ -10,6 +10,9 @@ ginkgo run --focus "stack: java-vertx starter: vertx-http-example"  -- -stacksPa
 
 test all starter project in a specific stack:
 ginkgo run --focus "stack: java-vertx"  -- -stacksPath ../../stacks
+
+specifying odo path:
+ginkgo run -v  -- -odoPath <path/to/odo/binary>
 */
 
 package main
@@ -37,10 +40,12 @@ import (
 
 var stacksPath string
 var stackDirs string
+var odoPath string
 
 func init() {
 	flag.StringVar(&stacksPath, "stacksPath", "../../stacks", "The path to the directory containing the stacks")
 	flag.StringVar(&stackDirs, "stackDirs", "", "The stacks to test as a string separated by spaces")
+	flag.StringVar(&odoPath, "odoPath", "odo", "The path to the odo binary, defaults to path symbol")
 }
 
 // all stacks to be tested
@@ -404,7 +409,7 @@ func runOdoDev(additionalArgs ...string) (io.ReadCloser, io.ReadCloser, *exec.Cm
 	args := []string{"dev", "--random-ports"}
 	args = append(args, additionalArgs...)
 	GinkgoWriter.Println("Executing odo " + strings.Join(args, " "))
-	cmd := exec.Command("odo", args...)
+	cmd := exec.Command(odoPath, args...)
 
 	stdout, err := cmd.StdoutPipe()
 	if err != nil {
@@ -426,8 +431,11 @@ func runOdoDev(additionalArgs ...string) (io.ReadCloser, io.ReadCloser, *exec.Cm
 // run odo commands
 // returns stdout, stderr, and error
 func runOdo(args ...string) ([]byte, []byte, error) {
+	// Clean given path
+	filepath.Clean(odoPath)
+
 	GinkgoWriter.Println("Executing: odo", strings.Join(args, " "))
-	cmd := exec.Command("odo", args...)
+	cmd := exec.Command(odoPath, args...)
 
 	stdout, err := cmd.StdoutPipe()
 	if err != nil {


### PR DESCRIPTION
# Description of Changes

Migrate jhipster online to red hat developer demo repo and image to quay devfile organization

GitHub
https://github.com/redhat-developer-demos/jhipster-online

Quay
https://quay.io/repository/devfile/jhipster-online

# Related Issue(s)
[_Link the GitHub/GitLab/JIRA issues that are related to this PR._](https://github.com/eclipse-che/che-website/pull/112#issuecomment-2561319046)

# How To Test
_Instructions for the reviewer on how to test your changes._

Taking a look at the [Video Demo](https://www.youtube.com/watch?v=b7xbcTAGNIQ)