### PR TITLE
chore(konflux): Migrate renovate configuration

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -6,8 +6,8 @@
     ":gitSignOff"
   ],
   "timezone": "America/Toronto",
-  "schedule": ["on the 2nd and 4th day instance on thursday after 9pm"],
-  "enabledManagers": ["regex", "github-actions"],
+  "schedule": ["after 9pm on tuesday and thursday"],
+  "enabledManagers": ["regex", "github-actions", "tekton"],
   "regexManagers": [
     {
       "fileMatch": [
@@ -21,12 +21,12 @@
     }
   ],
   "packageRules": [
-      {
-        "matchManagers": ["github-actions"],
-        "groupName": "github actions",
-        "groupSlug": "github-actions",
-        "commitMessageTopic": "{{depName}}"
-      }
+    {
+      "matchManagers": ["github-actions"],
+      "groupName": "github actions",
+      "groupSlug": "github-actions",
+      "commitMessageTopic": "{{depName}}"
+    }
   ],
   "ignorePaths": [
     "**/docker/**",


### PR DESCRIPTION
# Description of Changes
_Summarize the changes you made as part of this pull request._

This PR migrates the old renovate config to one that works with Konflux. In order to meet the needs of MintMaker Renovate via Konflux as well as the Konflux patch updates, the following changes have been made:
- Include `tekton` under `enabledManagers`
- Increase run schedule for renovate to avoid Enterprise Contract failures due to out of date Konflux image references

# Related Issue(s)
_Link the GitHub/GitLab/JIRA issues that are related to this PR._

fixes https://github.com/devfile/api/issues/1667

# Acceptance Criteria
<!-- _Check the relevant boxes below_ -->
- [ ] Contributing guide

_Have you read the [devfile registry contributing guide](https://github.com/devfile/registry/blob/main/CONTRIBUTING.md) and followed its instructions?_
- [ ] Test automation

_Does this repository's tests pass with your changes?_
- [ ] Documentation

_Does any documentation need to be updated with your changes?_
- [ ] Check Tools Provider

_Have you tested the changes with existing tools, i.e. Odo, Che, Console? (See [devfile registry contributing guide](https://github.com/devfile/registry/blob/main/CONTRIBUTING.md) on how to test changes)_


# Tests Performed
_Explain what tests you personally ran to ensure the changes are functioning as expected._

I ran the following to validate the renovate config file changes:

1. `export RENOVATE_CONFIG_FILE=$(pwd)/renovate.json`
2. `npx --yes --package renovate -- renovate-config-validator`

# How To Test
_Instructions for the reviewer on how to test your changes._

# Notes To Reviewer
_Any notes you would like to include for the reviewer._

Ignore warnings to migrate configuration, it appears MintMaker renovate is still using the old configuration specification.