### PR TITLE
Create Konflux patching renovate schedule

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -26,6 +26,11 @@
       "groupName": "github actions",
       "groupSlug": "github-actions",
       "commitMessageTopic": "{{depName}}"
+    },
+    {
+      "description": "Schedule Konflux tekton task updates Tuesday and Thursday nights (9 PM - 12 AM)",
+      "matchManagers": ["tekton"],
+      "schedule": ["* 21-23 * * 2,4"]
     }
   ],
   "ignorePaths": [

--- a/renovate.json
+++ b/renovate.json
@@ -6,7 +6,7 @@
     ":gitSignOff"
   ],
   "timezone": "America/Toronto",
-  "schedule": ["after 9pm on tuesday and thursday"],
+  "schedule": ["on the 2nd and 4th day instance on thursday after 9pm"],
   "enabledManagers": ["regex", "github-actions", "tekton"],
   "regexManagers": [
     {


### PR DESCRIPTION
# Description of Changes
_Summarize the changes you made as part of this pull request._

Creates a schedule for Konflux patching to happen every Tuesday and Thursday after 9pm, schedule specified in #553, restores default renovate schedule for other devfile registry patching to every 2nd and 4th Thursday after 9pm.

# Related Issue(s)
_Link the GitHub/GitLab/JIRA issues that are related to this PR._

# Acceptance Criteria
<!-- _Check the relevant boxes below_ -->
- [ ] Contributing guide

_Have you read the [devfile registry contributing guide](https://github.com/devfile/registry/blob/main/CONTRIBUTING.md) and followed its instructions?_
- [ ] Test automation

_Does this repository's tests pass with your changes?_
- [ ] Documentation

_Does any documentation need to be updated with your changes?_
- [ ] Check Tools Provider

_Have you tested the changes with existing tools, i.e. Odo, Che, Console? (See [devfile registry contributing guide](https://github.com/devfile/registry/blob/main/CONTRIBUTING.md) on how to test changes)_


# Tests Performed
_Explain what tests you personally ran to ensure the changes are functioning as expected._

I ran the following to validate the renovate config file changes:

1. `export RENOVATE_CONFIG_FILE=$(pwd)/renovate.json`
2. `npx --yes --package renovate -- renovate-config-validator`

# How To Test
_Instructions for the reviewer on how to test your changes._

# Notes To Reviewer
_Any notes you would like to include for the reviewer._

Ignore warnings to migrate configuration, it appears MintMaker renovate is still using the old configuration specification.