### PR TITLE
Upgrade JHipster Online Stack

### DIFF
--- a/stacks/jhipster-online/2.33.0/devfile.yaml
+++ b/stacks/jhipster-online/2.33.0/devfile.yaml
@@ -116,7 +116,3 @@ commands:
       group:
         kind: run
         isDefault: false
-events:
-  postStart:
-    - oc-add-mysql
-    - yarn-install

--- a/stacks/jhipster-online/2.33.0/devfile.yaml
+++ b/stacks/jhipster-online/2.33.0/devfile.yaml
@@ -119,4 +119,4 @@ commands:
 events:
   postStart:
     - oc-add-mysql
-    - yarn-install 
+    - yarn-install

--- a/stacks/jhipster-online/2.33.0/devfile.yaml
+++ b/stacks/jhipster-online/2.33.0/devfile.yaml
@@ -116,3 +116,7 @@ commands:
       group:
         kind: run
         isDefault: false
+events:
+  postStart:
+    - oc-add-mysql
+    - yarn-install

--- a/stacks/jhipster-online/2.33.0/devfile.yaml
+++ b/stacks/jhipster-online/2.33.0/devfile.yaml
@@ -1,7 +1,11 @@
 schemaVersion: 2.2.2
 metadata:
   name: jhipster-online
-  description: Stack with JHipster Online on Red Hat OpenShift Dev Spaces. JHipster 8.1.0.
+  description: "Stack with JHipster Online on Red Hat OpenShift Dev Spaces. 
+    This stack include:
+    - JHipster 8.1.0.
+    Watch the demo video:
+    - https://youtu.be/b7xbcTAGNIQ?si=snE57Th4S3gPv_Vn"  
   displayName: JHipster Online
   icon: https://raw.githubusercontent.com/redhat-developer-demos/jhipster-online/main/jhipster-icon.png
   website: https://start.jhipster.tech
@@ -23,7 +27,7 @@ projects:
 components:
   - name: tools
     container:
-      image: 'quay.io/devfile/jhipster-online@sha256:254c710006b1582b2ebc48cc74ae080a9e10caa99dc1b62c1adb3341f072aede'
+      image: 'quay.io/devfile/jhipster-online@sha256:1d34f067a20d87d7cfa5e304fef23556f865656dfa1c01cb8501ea078a03157e'
       mountSources: true
       cpuLimit: '4'
       cpuRequest: '1'

--- a/stacks/jhipster-online/2.33.0/devfile.yaml
+++ b/stacks/jhipster-online/2.33.0/devfile.yaml
@@ -3,7 +3,7 @@ metadata:
   name: jhipster-online
   description: "Stack with JHipster Online on Red Hat OpenShift Dev Spaces. 
     This stack include:
-    - JHipster 8.1.0.
+    - JHipster 8.1.0 for generate Spring Boot projects.
     Watch the demo video:
     - https://youtu.be/b7xbcTAGNIQ?si=snE57Th4S3gPv_Vn"  
   displayName: JHipster Online
@@ -23,11 +23,11 @@ projects:
       remotes:
         origin: 'https://github.com/redhat-developer-demos/jhipster-online'
       checkoutFrom:
-        revision: main
+        revision: 2.33.0
 components:
   - name: tools
     container:
-      image: 'quay.io/devfile/jhipster-online@sha256:1d34f067a20d87d7cfa5e304fef23556f865656dfa1c01cb8501ea078a03157e'
+      image: 'quay.io/devfile/jhipster-online@sha256:254c710006b1582b2ebc48cc74ae080a9e10caa99dc1b62c1adb3341f072aede'
       mountSources: true
       cpuLimit: '4'
       cpuRequest: '1'

--- a/stacks/jhipster-online/2.33.0/devfile.yaml
+++ b/stacks/jhipster-online/2.33.0/devfile.yaml
@@ -27,7 +27,7 @@ projects:
 components:
   - name: tools
     container:
-      image: 'quay.io/devfile/jhipster-online@sha256:254c710006b1582b2ebc48cc74ae080a9e10caa99dc1b62c1adb3341f072aede'
+      image: 'quay.io/devfile/jhipster-online@sha256:f1e75a7b35925ce8302408dacbeafbe377698fa4bea43ccdf2c08b693470dd27'
       mountSources: true
       cpuLimit: '4'
       cpuRequest: '1'

--- a/stacks/jhipster-online/2.33.1/devfile.yaml
+++ b/stacks/jhipster-online/2.33.1/devfile.yaml
@@ -4,12 +4,12 @@ metadata:
   version: 2.33.1
   description: "Stack with JHipster Online on Red Hat OpenShift Dev Spaces. 
     This stack include:
-    - JHipster 8.8.0. 
-    - generator-jhipster-micronaut 3.6.0. 
-    - generator-jhipster-quarkus 3.4.0.
-    - generator-jhipster-dotnetcore 4.2.0.
+    - JHipster 8.8.0. for generate Spring Boot 3.4.1 projects.
+    - generator-jhipster-micronaut 3.6.0 for generate Micronaut 4.7.2 projects.
+    - generator-jhipster-quarkus 3.4.0 for generate Quarkus 3.11.1 projects.
+    - generator-jhipster-dotnetcore 4.2.0 for generate .Net 8.0 projects.
     Watch the demo video:
-    - https://youtu.be/b7xbcTAGNIQ?si=snE57Th4S3gPv_Vn"  
+    - https://youtu.be/b7xbcTAGNIQ?si=snE57Th4S3gPv_Vn"    
   displayName: JHipster Online
   icon: https://raw.githubusercontent.com/redhat-developer-demos/jhipster-online/main/jhipster-icon.png
   website: https://start.jhipster.tech

--- a/stacks/jhipster-online/2.33.1/devfile.yaml
+++ b/stacks/jhipster-online/2.33.1/devfile.yaml
@@ -1,7 +1,8 @@
 schemaVersion: 2.2.2
 metadata:
   name: jhipster-online
-  description: Stack with JHipster Online on Red Hat OpenShift Dev Spaces. JHipster 8.1.0.
+  version: 2.33.1
+  description: Stack with the JHipster Online on Red Hat OpenShift Dev Spaces. JHipster 8.8.0. generator-jhipster-micronau 3.6.0. generator-jhipster-quarkus 3.4.0. generator-jhipster-dotnetcore 4.2.0.
   displayName: JHipster Online
   icon: https://raw.githubusercontent.com/redhat-developer-demos/jhipster-online/main/jhipster-icon.png
   website: https://start.jhipster.tech
@@ -10,9 +11,10 @@ metadata:
     - JHipster
     - Angular
     - Spring
+    - Quarkus
+    - Micronaut
   language: Java
   projectType: springboot
-  version: 2.33.0        
 projects:
   - name: jhipster-online
     git:
@@ -23,7 +25,7 @@ projects:
 components:
   - name: tools
     container:
-      image: 'quay.io/devfile/jhipster-online@sha256:254c710006b1582b2ebc48cc74ae080a9e10caa99dc1b62c1adb3341f072aede'
+      image: 'quay.io/devfile/jhipster-online@sha256:1d34f067a20d87d7cfa5e304fef23556f865656dfa1c01cb8501ea078a03157e'
       mountSources: true
       cpuLimit: '4'
       cpuRequest: '1'
@@ -55,7 +57,7 @@ components:
         - exposure: public
           name: browser-sync
           protocol: https
-          targetPort: 3001                    
+          targetPort: 3001
       env:
         - value: '-XX:MaxRAMPercentage=50.0 -XX:+UseParallelGC -XX:MinHeapFreeRatio=10 -XX:MaxHeapFreeRatio=20 -XX:GCTimeRatio=4 -XX:AdaptiveSizePolicyWeight=90 -Dsun.zip.disableMemoryMapping=true -Xms20m -Djava.security.egd=file:/dev/./urandom -Duser.home=/home/jboss'
           name: JAVA_OPTS
@@ -84,7 +86,13 @@ commands:
       label: 'OpenShift apply MariaDB Instance (OpenShift cluster)'
       component: tools
       workingDir: ${PROJECT_SOURCE}
-      commandLine: 'oc apply -f src/main/kubernetes/mysql.yaml'      
+      commandLine: 'oc apply -f src/main/kubernetes/mysql.yaml'
+  - id: oc-remove-mysql
+    exec:
+      label: 'OpenShift remove MariaDB Instance (OpenShift cluster)'
+      component: tools
+      workingDir: ${PROJECT_SOURCE}
+      commandLine: 'oc delete all --selector app=mariadb'
   - id: yarn-install
     exec:
       label: 'Package the application'
@@ -93,7 +101,7 @@ commands:
       commandLine: 'yarn install'
       group:
         kind: build
-        isDefault: true      
+        isDefault: true
   - id: start-frontend
     exec:
       label: 'Start Frontend'
@@ -102,7 +110,7 @@ commands:
       commandLine: 'yarn start'
       group:
         kind: run
-        isDefault: true                        
+        isDefault: true
   - id: start-backend
     exec:
       label: 'Start JHipster Online'
@@ -115,4 +123,4 @@ commands:
 events:
   postStart:
     - oc-add-mysql
-    - yarn-install 
+    - yarn-install

--- a/stacks/jhipster-online/2.33.1/devfile.yaml
+++ b/stacks/jhipster-online/2.33.1/devfile.yaml
@@ -32,7 +32,7 @@ projects:
 components:
   - name: tools
     container:
-      image: 'quay.io/devfile/jhipster-online@sha256:1d34f067a20d87d7cfa5e304fef23556f865656dfa1c01cb8501ea078a03157e'
+      image: 'quay.io/devfile/jhipster-online@sha256:1f284df66c8ef209ea2cd1a10516e9ba424508a11341eead650e88027858d3ee'
       mountSources: true
       cpuLimit: '4'
       cpuRequest: '1'

--- a/stacks/jhipster-online/2.33.1/devfile.yaml
+++ b/stacks/jhipster-online/2.33.1/devfile.yaml
@@ -1,4 +1,4 @@
-schemaVersion: 2.3.0
+schemaVersion: 2.2.0
 metadata:
   name: jhipster-online
   version: 2.33.1

--- a/stacks/jhipster-online/2.33.1/devfile.yaml
+++ b/stacks/jhipster-online/2.33.1/devfile.yaml
@@ -2,7 +2,14 @@ schemaVersion: 2.2.2
 metadata:
   name: jhipster-online
   version: 2.33.1
-  description: Stack with the JHipster Online on Red Hat OpenShift Dev Spaces. JHipster 8.8.0. generator-jhipster-micronau 3.6.0. generator-jhipster-quarkus 3.4.0. generator-jhipster-dotnetcore 4.2.0.
+  description: "Stack with JHipster Online on Red Hat OpenShift Dev Spaces. 
+    This stack include:
+    - JHipster 8.8.0. 
+    - generator-jhipster-micronaut 3.6.0. 
+    - generator-jhipster-quarkus 3.4.0.
+    - generator-jhipster-dotnetcore 4.2.0.
+    Watch the demo video:
+    - https://youtu.be/b7xbcTAGNIQ?si=snE57Th4S3gPv_Vn"  
   displayName: JHipster Online
   icon: https://raw.githubusercontent.com/redhat-developer-demos/jhipster-online/main/jhipster-icon.png
   website: https://start.jhipster.tech

--- a/stacks/jhipster-online/2.33.1/devfile.yaml
+++ b/stacks/jhipster-online/2.33.1/devfile.yaml
@@ -127,3 +127,7 @@ commands:
       group:
         kind: run
         isDefault: false
+events:
+  postStart:
+    - oc-add-mysql
+    - yarn-install

--- a/stacks/jhipster-online/2.33.1/devfile.yaml
+++ b/stacks/jhipster-online/2.33.1/devfile.yaml
@@ -1,4 +1,4 @@
-schemaVersion: 2.2.0
+schemaVersion: 2.2.2
 metadata:
   name: jhipster-online
   version: 2.33.1
@@ -127,7 +127,3 @@ commands:
       group:
         kind: run
         isDefault: false
-events:
-  postStart:
-    - oc-add-mysql
-    - yarn-install

--- a/stacks/jhipster-online/2.33.1/devfile.yaml
+++ b/stacks/jhipster-online/2.33.1/devfile.yaml
@@ -127,7 +127,3 @@ commands:
       group:
         kind: run
         isDefault: false
-events:
-  postStart:
-    - oc-add-mysql
-    - yarn-install

--- a/stacks/jhipster-online/2.33.1/devfile.yaml
+++ b/stacks/jhipster-online/2.33.1/devfile.yaml
@@ -1,4 +1,4 @@
-schemaVersion: 2.2.2
+schemaVersion: 2.3.0
 metadata:
   name: jhipster-online
   version: 2.33.1

--- a/stacks/jhipster-online/stack.yaml
+++ b/stacks/jhipster-online/stack.yaml
@@ -1,7 +1,8 @@
 name: jhipster-online
-description: Stack with JHipster Online on Red Hat OpenShift Dev Spaces
+description: Stack with JHipster Online on Red Hat OpenShift Dev Spaces. JHipster 8.8.0. generator-jhipster-micronau 3.6.0. generator-jhipster-quarkus 3.4.0. generator-jhipster-dotnetcore 4.2.0.
 displayName: JHipster Online
-icon: https://raw.githubusercontent.com/maximilianoPizarro/ecommerce-oracle/main/jhipster-icon.png
+icon: https://raw.githubusercontent.com/redhat-developer-demos/jhipster-online/main/jhipster-icon.png
 versions:
   - version: 2.33.0
+  - version: 2.33.1
     default: true

--- a/stacks/jhipster-online/stack.yaml
+++ b/stacks/jhipster-online/stack.yaml
@@ -1,5 +1,12 @@
 name: jhipster-online
-description: Stack with JHipster Online on Red Hat OpenShift Dev Spaces. JHipster 8.8.0. generator-jhipster-micronau 3.6.0. generator-jhipster-quarkus 3.4.0. generator-jhipster-dotnetcore 4.2.0.
+description: "Stack with JHipster Online on Red Hat OpenShift Dev Spaces. 
+  This stack include:
+  - JHipster 8.8.0. 
+  - generator-jhipster-micronaut 3.6.0. 
+  - generator-jhipster-quarkus 3.4.0.
+  - generator-jhipster-dotnetcore 4.2.0.
+  Watch the demo video:
+  - https://youtu.be/b7xbcTAGNIQ?si=snE57Th4S3gPv_Vn"
 displayName: JHipster Online
 icon: https://raw.githubusercontent.com/redhat-developer-demos/jhipster-online/main/jhipster-icon.png
 versions:

--- a/stacks/jhipster-online/stack.yaml
+++ b/stacks/jhipster-online/stack.yaml
@@ -1,10 +1,10 @@
 name: jhipster-online
 description: "Stack with JHipster Online on Red Hat OpenShift Dev Spaces. 
   This stack include:
-  - JHipster 8.8.0. 
-  - generator-jhipster-micronaut 3.6.0. 
-  - generator-jhipster-quarkus 3.4.0.
-  - generator-jhipster-dotnetcore 4.2.0.
+  - JHipster 8.8.0. for generate Spring Boot 3.4.1 projects.
+  - generator-jhipster-micronaut 3.6.0 for generate Micronaut 4.7.2 projects.
+  - generator-jhipster-quarkus 3.4.0 for generate Quarkus 3.11.1 projects.
+  - generator-jhipster-dotnetcore 4.2.0 for generate .Net 8.0 projects.
   Watch the demo video:
   - https://youtu.be/b7xbcTAGNIQ?si=snE57Th4S3gPv_Vn"
 displayName: JHipster Online

--- a/tests/check_odov3.sh
+++ b/tests/check_odov3.sh
@@ -55,7 +55,7 @@ ginkgo run --procs 2 \
   --skip="stack: java-vertx version: 1.4.0 starter: vertx-messaging-work-queue-booster" \
   --skip="stack: java-websphereliberty-gradle version: 0.4.0 starter: rest" \
   --skip="stack: jhipster-online version: 2.33.0 starter: jhipster-online" \
-  --skip="stack: jhipster-online version: 2.33.1 starter: jhipster-online" \  
+  --skip="stack: jhipster-online version: 2.33.1 starter: jhipster-online" \
   --skip="stack: java-wildfly-bootable-jar" \
   --skip="stack: java-wildfly" \
   --skip="stack: java-openliberty" \

--- a/tests/check_odov3.sh
+++ b/tests/check_odov3.sh
@@ -54,8 +54,7 @@ ginkgo run --procs 2 \
   --skip="stack: java-vertx version: 1.4.0 starter: vertx-istio-security-booster" \
   --skip="stack: java-vertx version: 1.4.0 starter: vertx-messaging-work-queue-booster" \
   --skip="stack: java-websphereliberty-gradle version: 0.4.0 starter: rest" \
-  --skip="stack: jhipster-online version: 2.33.0 starter: jhipster-online" \
-  --skip="stack: jhipster-online version: 2.33.1 starter: jhipster-online" \
+  --skip="stack: jhipster-online" \
   --skip="stack: java-wildfly-bootable-jar" \
   --skip="stack: java-wildfly" \
   --skip="stack: java-openliberty" \

--- a/tests/check_odov3.sh
+++ b/tests/check_odov3.sh
@@ -55,6 +55,7 @@ ginkgo run --procs 2 \
   --skip="stack: java-vertx version: 1.4.0 starter: vertx-messaging-work-queue-booster" \
   --skip="stack: java-websphereliberty-gradle version: 0.4.0 starter: rest" \
   --skip="stack: jhipster-online version: 2.33.0 starter: jhipster-online" \
+  --skip="stack: jhipster-online version: 2.33.1 starter: jhipster-online" \  
   --skip="stack: java-wildfly-bootable-jar" \
   --skip="stack: java-wildfly" \
   --skip="stack: java-openliberty" \


### PR DESCRIPTION
# Description of Changes

Added new devfile 2.33.1 with the next updates:

- Update JHipster Core: jhipster 8.8.0

Added Blueprints:

- generator-jhipster-micronau 3.6.0
- generator-jhipster-quarkus 3.4.0
- generator-jhipster-dotnetcore 4.2.0

Upgrade jhipster udi image.

- quay.io/devfile/jhipster-online@sha256:1d34f067a20d87d7cfa5e304fef23556f865656dfa1c01cb8501ea078a03157e


Example Try with Quarkus Generator:

Modify cmd key jhipster by jhipster-quarkus from application section:

```
application:
  tmp-folder: /tmp
  jhipster-cmd:
    #cmd: jhipster
    cmd: jhipster-quarkus
```

Modify url-pipeline key by url-pipeline quarkus example:

```
openshift:
  devspace:
    url-devfile: https://raw.githubusercontent.com/redhat-developer-demos/jhipster-online/main/src/main/kubernetes/jhipster-devspaces.yaml
  tekton:
    url-pipeline: https://raw.githubusercontent.com/redhat-developer-demos/jhipster-online/main/src/main/kubernetes/jhipster-pipeline-quarkus.yaml
    url-pipeline-run: https://raw.githubusercontent.com/redhat-developer-demos/jhipster-online/main/src/main/kubernetes/jhipster-pipeline-run.yaml
```

Example Repo Output with Spring Boot Generator:

- https://github.com/maximilianoPizarro/jhipster-test


Example Repo Output with Quarkus Generator

- https://github.com/maximilianoPizarro/jhipster-quarkus-test

Example Repo Output with Micronaut Generator

- https://github.com/maximilianoPizarro/mhipster-test

Example Repo Output with Quarkus Generator

- https://github.com/maximilianoPizarro/jhipster-dotnet-test

I look forward to hearing your comments. 
Thanks in advance Team.