### PR TITLE
chore: upgrade udi/devfile to use UBI9 based image

### DIFF
--- a/stacks/udi/devfile.yaml
+++ b/stacks/udi/devfile.yaml
@@ -14,14 +14,14 @@ metadata:
     - Go
     - Python
     - Pip
-    - ubi8
+    - ubi9
   projectType: universal
   language: Polyglot
   version: 1.0.0
 components:
   - name: tools
     container:
-      image: quay.io/devfile/universal-developer-image:ubi8-latest
+      image: quay.io/devfile/universal-developer-image:ubi9-latest
       memoryLimit: 6G
       memoryRequest: 512Mi
       cpuRequest: 1000m


### PR DESCRIPTION
# Description of Changes
This PR updates image that is used in UDI stack. 

**quay.io/devfile/universal-developer-image:ubi8-latest** is not supported anymore, it was replaced by UBI9 based image. 
For more details check https://github.com/eclipse-che/che/issues/23034.

# Related Issue(s)
https://github.com/eclipse-che/che/issues/23034

# Tests Performed
Tested on Eclipse Che

![screenshot-github_com-2025_04_25-12_03_19](https://github.com/user-attachments/assets/eed6ec67-754c-4a90-8d9c-5e0950c9bd53)

# How To Test
Workspace should start from the udi/devfile.yaml
