### PR TITLE
Bump up registry go version to 1.23 and odo to 3.16.1

### DIFF
--- a/.ci/Dockerfile
+++ b/.ci/Dockerfile
@@ -14,7 +14,7 @@
 #   limitations under the License.
 ARG BASE_IMAGE=quay.io/devfile/devfile-index-base:next
 
-FROM registry.access.redhat.com/ubi8/go-toolset:1.21 AS builder
+FROM registry.access.redhat.com/ubi8/go-toolset:1.24 AS builder
 
 # Set user as root
 USER root

--- a/.ci/Dockerfile
+++ b/.ci/Dockerfile
@@ -14,7 +14,7 @@
 #   limitations under the License.
 ARG BASE_IMAGE=quay.io/devfile/devfile-index-base:next
 
-FROM registry.access.redhat.com/ubi8/go-toolset:1.24 AS builder
+FROM registry.access.redhat.com/ubi8/go-toolset:1.23 AS builder
 
 # Set user as root
 USER root

--- a/.ci/Dockerfile.offline
+++ b/.ci/Dockerfile.offline
@@ -14,7 +14,7 @@
 #   limitations under the License.
 ARG BASE_IMAGE=quay.io/devfile/devfile-index-base:next
 
-FROM registry.access.redhat.com/ubi8/go-toolset:1.21 AS builder
+FROM registry.access.redhat.com/ubi8/go-toolset:1.24 AS builder
 
 # Set user as root
 USER root

--- a/.ci/Dockerfile.offline
+++ b/.ci/Dockerfile.offline
@@ -14,7 +14,7 @@
 #   limitations under the License.
 ARG BASE_IMAGE=quay.io/devfile/devfile-index-base:next
 
-FROM registry.access.redhat.com/ubi8/go-toolset:1.24 AS builder
+FROM registry.access.redhat.com/ubi8/go-toolset:1.23 AS builder
 
 # Set user as root
 USER root

--- a/.devfile.yaml
+++ b/.devfile.yaml
@@ -43,7 +43,7 @@ components:
 # Alternatively could be removed once https://github.com/redhat-developer/odo/issues/7162 is resolved
   - name: index-generator
     container:
-      image: registry.access.redhat.com/ubi8/go-toolset:1.21.11-8.1724181402
+      image: registry.access.redhat.com/ubi8/go-toolset:1.23.6-4
 # Devfile Registry Deployment resource
   - name: devfile-registry-deployment
     kubernetes:

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -36,7 +36,7 @@ jobs:
       - name: Setup Go environment
         uses: actions/setup-go@3041bf56c941b39c61721a86cd11f3bb1338122a # v5.2.0
         with:
-          go-version: 1.21
+          go-version: 1.24
       - name: Set up QEMU # Enables arm64 image building
         uses: docker/setup-qemu-action@8b562efa09ec1557a9e26f25a7c6292838acea94 
 

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -36,7 +36,7 @@ jobs:
       - name: Setup Go environment
         uses: actions/setup-go@3041bf56c941b39c61721a86cd11f3bb1338122a # v5.2.0
         with:
-          go-version: 1.24
+          go-version: 1.23
       - name: Set up QEMU # Enables arm64 image building
         uses: docker/setup-qemu-action@8b562efa09ec1557a9e26f25a7c6292838acea94 
 

--- a/.github/workflows/pushimge-next.yaml
+++ b/.github/workflows/pushimge-next.yaml
@@ -41,7 +41,7 @@ jobs:
       - name: Setup Go environment
         uses: actions/setup-go@3041bf56c941b39c61721a86cd11f3bb1338122a # v5.2.0
         with:
-          go-version: 1.21
+          go-version: 1.24
       - name: Set up QEMU # Enables arm64 image building
         uses: docker/setup-qemu-action@8b562efa09ec1557a9e26f25a7c6292838acea94
       - name: Login to Quay

--- a/.github/workflows/pushimge-next.yaml
+++ b/.github/workflows/pushimge-next.yaml
@@ -41,7 +41,7 @@ jobs:
       - name: Setup Go environment
         uses: actions/setup-go@3041bf56c941b39c61721a86cd11f3bb1338122a # v5.2.0
         with:
-          go-version: 1.24
+          go-version: 1.23
       - name: Set up QEMU # Enables arm64 image building
         uses: docker/setup-qemu-action@8b562efa09ec1557a9e26f25a7c6292838acea94
       - name: Login to Quay

--- a/.github/workflows/validate-samples.yaml
+++ b/.github/workflows/validate-samples.yaml
@@ -44,7 +44,7 @@ jobs:
       - name: Install Go
         uses: actions/setup-go@3041bf56c941b39c61721a86cd11f3bb1338122a # v5.2.0
         with:
-          go-version: "1.21"
+          go-version: "1.24"
 
       - name: Install Ginkgo
         run: go install -mod=mod github.com/onsi/ginkgo/v2/ginkgo@v2.13.0

--- a/.github/workflows/validate-samples.yaml
+++ b/.github/workflows/validate-samples.yaml
@@ -44,7 +44,7 @@ jobs:
       - name: Install Go
         uses: actions/setup-go@3041bf56c941b39c61721a86cd11f3bb1338122a # v5.2.0
         with:
-          go-version: "1.24"
+          go-version: "1.23"
 
       - name: Install Ginkgo
         run: go install -mod=mod github.com/onsi/ginkgo/v2/ginkgo@v2.13.0

--- a/.github/workflows/validate-stacks.yaml
+++ b/.github/workflows/validate-stacks.yaml
@@ -165,10 +165,10 @@ jobs:
         with:
           go-version: "1.23"
 
-      - name: Install odo latest version
-        run: |
-          curl -L https://s3.eu-de.cloud-object-storage.appdomain.cloud/odo-nightly-builds/odo-linux-amd64 -o odo
-          sudo install -m 0755 odo /usr/local/bin/odo
+      - name: Install odo latest version v3
+        uses: redhat-actions/openshift-tools-installer@2de9a80cf012ad0601021515481d433b91ef8fd5 # v1
+        with:
+          odo: "3.16.1"
 
       - name: Install Ginkgo
         run: go install -mod=mod github.com/onsi/ginkgo/v2/ginkgo@v2.13.0

--- a/.github/workflows/validate-stacks.yaml
+++ b/.github/workflows/validate-stacks.yaml
@@ -46,7 +46,7 @@ jobs:
       - name: Install Go
         uses: actions/setup-go@3041bf56c941b39c61721a86cd11f3bb1338122a # v5.2.0
         with:
-          go-version: "1.24"
+          go-version: "1.23"
 
       - name: Install Ginkgo
         run: go install -mod=mod github.com/onsi/ginkgo/v2/ginkgo@v2.13.0
@@ -163,7 +163,7 @@ jobs:
       - name: Install Go
         uses: actions/setup-go@3041bf56c941b39c61721a86cd11f3bb1338122a # v5.2.0
         with:
-          go-version: "1.24"
+          go-version: "1.23"
 
       - name: Install odo latest version
         run: |

--- a/.github/workflows/validate-stacks.yaml
+++ b/.github/workflows/validate-stacks.yaml
@@ -46,7 +46,7 @@ jobs:
       - name: Install Go
         uses: actions/setup-go@3041bf56c941b39c61721a86cd11f3bb1338122a # v5.2.0
         with:
-          go-version: "1.21"
+          go-version: "1.24"
 
       - name: Install Ginkgo
         run: go install -mod=mod github.com/onsi/ginkgo/v2/ginkgo@v2.13.0
@@ -163,7 +163,7 @@ jobs:
       - name: Install Go
         uses: actions/setup-go@3041bf56c941b39c61721a86cd11f3bb1338122a # v5.2.0
         with:
-          go-version: "1.21"
+          go-version: "1.24"
 
       - name: Install odo latest version
         run: |

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ The public registry is updated weekly, by 12pm EST Wednesdays, with any updated 
 
 ## Registry Status
 
-![Go](https://img.shields.io/badge/Go-1.21-blue)
+![Go](https://img.shields.io/badge/Go-1.24-blue)
 [![Validate Devfile stacks](https://github.com/devfile/registry/actions/workflows/validate-stacks.yaml/badge.svg?event=schedule)](https://github.com/devfile/registry/actions/workflows/validate-stacks.yaml)
 [![Renovate][1]][2]
 

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ The public registry is updated weekly, by 12pm EST Wednesdays, with any updated 
 
 ## Registry Status
 
-![Go](https://img.shields.io/badge/Go-1.24-blue)
+![Go](https://img.shields.io/badge/Go-1.23-blue)
 [![Validate Devfile stacks](https://github.com/devfile/registry/actions/workflows/validate-stacks.yaml/badge.svg?event=schedule)](https://github.com/devfile/registry/actions/workflows/validate-stacks.yaml)
 [![Renovate][1]][2]
 

--- a/tests/check_non_terminating/go.mod
+++ b/tests/check_non_terminating/go.mod
@@ -1,6 +1,6 @@
 module github.com/devfile/registry/tests/check_non_terminating
 
-go 1.21
+go 1.24
 
 require github.com/devfile/library/v2 v2.3.0
 

--- a/tests/check_non_terminating/go.mod
+++ b/tests/check_non_terminating/go.mod
@@ -1,6 +1,6 @@
 module github.com/devfile/registry/tests/check_non_terminating
 
-go 1.24
+go 1.23
 
 require github.com/devfile/library/v2 v2.3.0
 

--- a/tests/odov3/go.mod
+++ b/tests/odov3/go.mod
@@ -1,6 +1,6 @@
 module github.com/devfile/registry/tests/odov3
 
-go 1.21
+go 1.24
 
 require (
 	github.com/devfile/api/v2 v2.3.0

--- a/tests/odov3/go.mod
+++ b/tests/odov3/go.mod
@@ -1,6 +1,6 @@
 module github.com/devfile/registry/tests/odov3
 
-go 1.24
+go 1.23
 
 require (
 	github.com/devfile/api/v2 v2.3.0

--- a/tests/validate_devfile_schemas/go.mod
+++ b/tests/validate_devfile_schemas/go.mod
@@ -1,6 +1,6 @@
 module github.com/devfile/registry/tests/validate_devfiles
 
-go 1.21
+go 1.24
 
 require (
 	github.com/devfile/library/v2 v2.3.0

--- a/tests/validate_devfile_schemas/go.mod
+++ b/tests/validate_devfile_schemas/go.mod
@@ -1,6 +1,6 @@
 module github.com/devfile/registry/tests/validate_devfiles
 
-go 1.24
+go 1.23
 
 require (
 	github.com/devfile/library/v2 v2.3.0


### PR DESCRIPTION
# Description of Changes

Bumps up the tests of the registry to go version 1.23 as that the UBI8 go-toolset has no tag on 1.24 only 1.23.

See: https://catalog.redhat.com/software/containers/ubi8/go-toolset/5ce8713aac3db925c03774d1

Additionally, as shared by the odo team the odo nightly builds are no longer supported, thus the current PR uses the newest version of odo (3.16.1) which includes the support for devfile versions 2.2.1 & 2.2.2

# Related Issue(s)

Fixes https://github.com/devfile/api/issues/1697
Fixes https://github.com/devfile/api/issues/1714

# Acceptance Criteria
<!-- _Check the relevant boxes below_ -->
- [ ] Contributing guide

_Have you read the [devfile registry contributing guide](https://github.com/devfile/registry/blob/main/CONTRIBUTING.md) and followed its instructions?_
- [ ] Test automation

_Does this repository's tests pass with your changes?_
- [ ] Documentation

_Does any documentation need to be updated with your changes?_
- [ ] Check Tools Provider

_Have you tested the changes with existing tools, i.e. Odo, Che, Console? (See [devfile registry contributing guide](https://github.com/devfile/registry/blob/main/CONTRIBUTING.md) on how to test changes)_


# Tests Performed
_Explain what tests you personally ran to ensure the changes are functioning as expected._

# How To Test
_Instructions for the reviewer on how to test your changes._

# Notes To Reviewer
_Any notes you would like to include for the reviewer._