### PR TITLE
fix: Adjust renovate schedules for wider time windows

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -6,7 +6,7 @@
     ":gitSignOff"
   ],
   "timezone": "America/Toronto",
-  "schedule": ["on the 2nd and 4th day instance on thursday after 9pm"],
+  "schedule": ["* 19-23,0-2 */2,4 * 4"],
   "enabledManagers": ["regex", "github-actions", "tekton"],
   "regexManagers": [
     {
@@ -28,9 +28,9 @@
       "commitMessageTopic": "{{depName}}"
     },
     {
-      "description": "Schedule Konflux tekton task updates Tuesday and Thursday nights (9 PM - 12 AM)",
+      "description": "Schedule Konflux tekton task updates Tuesday and Thursday nights (7 PM - 2 AM)",
       "matchManagers": ["tekton"],
-      "schedule": ["* 21-23 * * 2,4"]
+      "schedule": ["* 19-23,0-2 * * 2,4"]
     }
   ],
   "ignorePaths": [


### PR DESCRIPTION
# Description of Changes

Adjust the time windows for renovate PRs to be between 7pm-2am EST to cover more of the Konflux mintmaker renovate run schedule.

# Related Issue(s)

https://github.com/devfile/api/issues/1716

# Acceptance Criteria
<!-- _Check the relevant boxes below_ -->
- [X] Contributing guide

_Have you read the [devfile registry contributing guide](https://github.com/devfile/registry/blob/main/CONTRIBUTING.md) and followed its instructions?_
- [ ] Test automation

_Does this repository's tests pass with your changes?_
- [ ] Documentation

_Does any documentation need to be updated with your changes?_
- [ ] Check Tools Provider

_Have you tested the changes with existing tools, i.e. Odo, Che, Console? (See [devfile registry contributing guide](https://github.com/devfile/registry/blob/main/CONTRIBUTING.md) on how to test changes)_


# Tests Performed
_Explain what tests you personally ran to ensure the changes are functioning as expected._

# How To Test
_Instructions for the reviewer on how to test your changes._

# Notes To Reviewer
_Any notes you would like to include for the reviewer._