### PR TITLE
feat: add ZeroClaw AI agent runtime stack

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -62,3 +62,6 @@
 
 # OpenClaw stacks
 /stacks/openclaw/ @akurinnoy
+
+# ZeroClaw stacks
+/stacks/zeroclaw/ @akurinnoy

--- a/stacks/zeroclaw/1.0.0/devfile.yaml
+++ b/stacks/zeroclaw/1.0.0/devfile.yaml
@@ -1,0 +1,91 @@
+# ZeroClaw — AI Agent Gateway/Runtime Stack
+#
+# ZeroClaw is an open-source Rust-based AI agent gateway/runtime.
+# Repo: https://github.com/zeroclaw-labs/zeroclaw
+#
+# The daemon container runs the zeroclaw daemon which provides:
+#   - Gateway server on port 42617 — webhooks, websockets, web UI
+#
+# The editor (VS Code, ttyd, etc.) is chosen separately in the dashboard
+# and injected into the tools container.
+#
+# First boot: run `zeroclaw quickstart` in the terminal to create
+# your first agent, then restart the workspace.
+
+schemaVersion: 2.2.2
+metadata:
+  name: zeroclaw
+  displayName: ZeroClaw AI Agent Runtime
+  description: A fast, lightweight AI agent runtime. 50+ integrations, webhooks, websockets, and a web UI — all in one binary.
+  icon: https://raw.githubusercontent.com/zeroclaw-labs/zeroclaw/master/apps/tauri/icons/icon.png
+  tags:
+    - AI
+    - Agent
+    - Gateway
+    - ZeroClaw
+  projectType: AI
+  language: Polyglot
+  version: 1.0.0
+
+attributes:
+  controller.devfile.io/storage-type: per-workspace
+
+components:
+  - name: tools
+    container:
+      image: quay.io/devfile/universal-developer-image:ubi9-latest
+      memoryLimit: 1Gi
+      memoryRequest: 256Mi
+      mountSources: true
+
+  # ZeroClaw daemon container.
+  # Runs the daemon (gateway on port 42617).
+  # Config persists in the PVC at /home/user/.zeroclaw.
+  - name: zeroclaw
+    container:
+      image: quay.io/che-incubator/zeroclaw-image:latest
+      mountSources: false
+      memoryRequest: 256Mi
+      memoryLimit: 1Gi
+      args: ["daemon", "--host", "0.0.0.0"]
+      env:
+        - name: HOME
+          value: /home/user
+        - name: ZEROCLAW_DATA_DIR
+          value: /home/user/.zeroclaw/data
+      endpoints:
+        - name: gateway
+          targetPort: 42617
+          exposure: public
+          protocol: https
+          attributes:
+            cookiesAuthEnabled: true
+            discoverable: false
+            urlRewriteSupported: false
+      volumeMounts:
+        - name: zeroclaw-data
+          path: /home/user/.zeroclaw
+
+  - name: zeroclaw-data
+    volume:
+      size: 1Gi
+
+commands:
+  - id: quickstart
+    exec:
+      label: "Create your first agent (quickstart)"
+      component: zeroclaw
+      commandLine: zeroclaw quickstart
+      workingDir: /home/user
+  - id: status
+    exec:
+      label: "Show ZeroClaw status"
+      component: zeroclaw
+      commandLine: zeroclaw status
+      workingDir: /home/user
+  - id: doctor
+    exec:
+      label: "Run diagnostics"
+      component: zeroclaw
+      commandLine: zeroclaw doctor
+      workingDir: /home/user

--- a/stacks/zeroclaw/1.0.0/devfile.yaml
+++ b/stacks/zeroclaw/1.0.0/devfile.yaml
@@ -12,7 +12,7 @@
 # First boot: run `zeroclaw quickstart` in the terminal to create
 # your first agent, then restart the workspace.
 
-schemaVersion: 2.2.2
+schemaVersion: 2.3.0
 metadata:
   name: zeroclaw
   displayName: ZeroClaw AI Agent Runtime

--- a/stacks/zeroclaw/stack.yaml
+++ b/stacks/zeroclaw/stack.yaml
@@ -1,0 +1,7 @@
+name: zeroclaw
+displayName: ZeroClaw AI Agent Runtime
+description: A fast, lightweight AI agent runtime. 50+ integrations, webhooks, websockets, and a web UI — all in one binary.
+icon: https://raw.githubusercontent.com/zeroclaw-labs/zeroclaw/master/apps/tauri/icons/icon.png
+versions:
+  - version: 1.0.0
+    default: true

--- a/tests/check_odov3.sh
+++ b/tests/check_odov3.sh
@@ -75,6 +75,7 @@ ginkgo run --mod=readonly --procs 2 \
   --skip="stack: ollama" \
   --skip="stack: hermes" \
   --skip="stack: openclaw" \
+  --skip="stack: zeroclaw" \
   --slow-spec-threshold 120s \
   --timeout 3h \
   tests/odov3 -- -stacksPath "$stacksPath" -stackDirs "$stackDirs" ${args}


### PR DESCRIPTION
# Description of Changes

Add ZeroClaw as a devfile registry sample - an open-source Rust-based AI agent runtime by ZeroClaw Labs.

The stack runs the ZeroClaw daemon in a sidecar container:
- Gateway server on port 42617 - webhooks, websockets, and web dashboard

The official ZeroClaw image is distroless, so we use a wrapper image (`quay.io/che-incubator/zeroclaw-image`) that adds a shell environment on UBI9-minimal. The wrapper is built from [che-incubator/zeroclaw-image](https://github.com/che-incubator/zeroclaw-image).

The editor (VS Code, ttyd, etc.) is chosen separately in the dashboard and injected into the `tools` container.

# Related Issue(s)

N/A

# Acceptance Criteria
<!-- _Check the relevant boxes below_ -->
- [x] Contributing guide

_Have you read the [devfile registry contributing guide](https://github.com/devfile/registry/blob/main/CONTRIBUTING.md) and followed its instructions?_
- [x] Test automation

_Does this repository's tests pass with your changes?_
- [ ] Documentation

_Does any documentation need to be updated with your changes?_
- [x] Check Tools Provider

_Have you tested the changes with existing tools, i.e. Odo, Che, Console? (See [devfile registry contributing guide](https://github.com/devfile/registry/blob/main/CONTRIBUTING.md) on how to test changes)_


# Tests Performed

- Schema validation passed locally (`bash tests/validate_devfile_schemas.sh`)
- `odo init` passed locally with odo v3.16.1
- Started a workspace from the ZeroClaw sample on an OpenShift cluster (CRC, both amd64 and arm64)
- Verified the gateway/dashboard is accessible on port 42617
- Ran `zeroclaw quickstart`, `zeroclaw status`, and `zeroclaw doctor` from the terminal
- Confirmed config persists across workspace restarts (PVC at `/home/user/.zeroclaw`)

# How To Test

1. Build a custom devfile registry image with this change
2. Deploy it to a Che/DevSpaces cluster
3. Create a workspace from the ZeroClaw sample
4. Open the gateway endpoint and run `zeroclaw quickstart` to create your first agent
5. Verify the dashboard works

# Notes To Reviewer

- The official ZeroClaw image is distroless (no shell). This sample uses a [wrapper image](https://github.com/che-incubator/zeroclaw-image) that adds `bash` and coreutils on UBI9-minimal
- The daemon is started via `args: ["daemon", "--host", "0.0.0.0"]` to bypass the wrapper's default entrypoint config step (already handled at image build time)
- The endpoint uses `cookiesAuthEnabled: true` for authentication through the Che gateway
- No `starterProjects` - the sample is a standalone agent runtime, not a code project

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a new ZeroClaw stack for launching the AI agent gateway/runtime.
  * Provided a ready-to-use workspace with tools support, a ZeroClaw service container, persistent storage, and a public HTTPS gateway endpoint with cookie-based auth.
  * Included built-in commands for quick start, status, and diagnostics.
* **Tests**
  * Updated the ODOV3 test run to skip the ZeroClaw stack.
* **Chores**
  * Added stack-specific code ownership rules.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->