### PR TITLE
feat: add Hermes AI agent stack

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -56,3 +56,6 @@
 
 # Kaoto stacks
 /stacks/kaoto/ @maximilianoPizarro @devfile/che-team
+
+# Hermes stacks
+/stacks/hermes/ @akurinnoy

--- a/stacks/hermes/1.0.0/devfile.yaml
+++ b/stacks/hermes/1.0.0/devfile.yaml
@@ -1,0 +1,117 @@
+# Hermes — Self-Improving AI Agent Stack
+#
+# Hermes Agent is a self-improving AI agent by Nous Research.
+# Repo: https://github.com/NousResearch/hermes-agent
+#
+# The hermes container runs the agent runtime which provides:
+#   - Dashboard web UI on port 9119
+#   - Messaging gateway for Telegram, Discord, Slack, etc.
+#   - TUI and CLI chat interfaces
+#
+# The editor (VS Code, ttyd, etc.) is chosen separately in the dashboard
+# and injected into the tools container.
+#
+# First boot: run `hermes setup` in the terminal to configure
+# your API key and model.
+
+schemaVersion: 2.2.2
+metadata:
+  name: hermes
+  displayName: Hermes AI Agent
+  description: A self-improving AI agent with tool-calling, web dashboard, and 50+ integrations. By Nous Research.
+  icon: https://raw.githubusercontent.com/NousResearch/hermes-agent/main/apps/desktop/assets/icon.png
+  tags:
+    - AI
+    - Agent
+    - Hermes
+    - NousResearch
+  projectType: AI
+  language: Polyglot
+  version: 1.0.0
+
+attributes:
+  controller.devfile.io/storage-type: per-workspace
+
+components:
+  - name: tools
+    container:
+      image: quay.io/devfile/universal-developer-image:ubi9-latest
+      memoryLimit: 1Gi
+      memoryRequest: 256Mi
+      mountSources: true
+
+  # Hermes Agent container.
+  # Runs the agent runtime with dashboard on port 9119.
+  # The official image uses s6-overlay which requires root, so we
+  # bypass it and run the setup + dashboard directly.
+  # Config persists in the PVC at /opt/data (HERMES_HOME).
+  - name: hermes
+    container:
+      image: docker.io/nousresearch/hermes-agent:v2026.6.5
+      mountSources: false
+      memoryRequest: 512Mi
+      memoryLimit: 2Gi
+      command: ["/bin/bash", "-c"]
+      args:
+        - |
+          if ! whoami &>/dev/null; then
+            echo "user:x:$(id -u):0:user:/opt/data:/bin/bash" >> /etc/passwd
+          fi
+          export HOME=/opt/data
+          cd /opt/data
+
+          . /opt/hermes/.venv/bin/activate
+
+          for d in cron sessions logs hooks memories skills skins plans workspace home; do
+            mkdir -p /opt/data/$d
+          done
+          [ ! -f /opt/data/.env ] && cp /opt/hermes/.env.example /opt/data/.env 2>/dev/null && chmod 600 /opt/data/.env
+          [ ! -f /opt/data/config.yaml ] && cp /opt/hermes/cli-config.yaml.example /opt/data/config.yaml 2>/dev/null
+          [ ! -f /opt/data/SOUL.md ] && cp /opt/hermes/docker/SOUL.md /opt/data/SOUL.md 2>/dev/null
+
+          python /opt/hermes/tools/skills_sync.py 2>/dev/null || true
+
+          hermes dashboard --host 0.0.0.0 --no-open --insecure &
+          exec tail -f /dev/null
+      endpoints:
+        - name: dashboard
+          targetPort: 9119
+          exposure: public
+          protocol: https
+          attributes:
+            cookiesAuthEnabled: true
+            discoverable: false
+            urlRewriteSupported: false
+      volumeMounts:
+        - name: hermes-data
+          path: /opt/data
+
+  - name: hermes-data
+    volume:
+      size: 10Gi
+
+commands:
+  - id: setup
+    exec:
+      label: "Configure Hermes (setup wizard)"
+      component: hermes
+      commandLine: hermes setup
+      workingDir: /opt/data
+  - id: status
+    exec:
+      label: "Show Hermes status"
+      component: hermes
+      commandLine: hermes status
+      workingDir: /opt/data
+  - id: doctor
+    exec:
+      label: "Run diagnostics"
+      component: hermes
+      commandLine: hermes doctor
+      workingDir: /opt/data
+  - id: restart-dashboard
+    exec:
+      label: "Restart Hermes dashboard"
+      component: hermes
+      commandLine: hermes dashboard --stop 2>/dev/null; hermes dashboard --host 0.0.0.0 --no-open --insecure
+      workingDir: /opt/data

--- a/stacks/hermes/1.0.0/devfile.yaml
+++ b/stacks/hermes/1.0.0/devfile.yaml
@@ -14,7 +14,7 @@
 # First boot: run `hermes setup` in the terminal to configure
 # your API key and model.
 
-schemaVersion: 2.2.2
+schemaVersion: 2.3.0
 metadata:
   name: hermes
   displayName: Hermes AI Agent

--- a/stacks/hermes/stack.yaml
+++ b/stacks/hermes/stack.yaml
@@ -1,0 +1,7 @@
+name: hermes
+displayName: Hermes AI Agent
+description: A self-improving AI agent with tool-calling, web dashboard, and 50+ integrations. By Nous Research.
+icon: https://raw.githubusercontent.com/NousResearch/hermes-agent/main/apps/desktop/assets/icon.png
+versions:
+  - version: 1.0.0
+    default: true

--- a/tests/check_odov3.sh
+++ b/tests/check_odov3.sh
@@ -73,6 +73,7 @@ ginkgo run --mod=readonly --procs 2 \
   --skip="stack: java-websphereliberty" \
   --skip="stack: java-quarkus" \
   --skip="stack: ollama" \
+  --skip="stack: hermes" \
   --slow-spec-threshold 120s \
   --timeout 3h \
   tests/odov3 -- -stacksPath "$stacksPath" -stackDirs "$stackDirs" ${args}


### PR DESCRIPTION
# Description of Changes

Add Hermes Agent as a devfile registry sample - a self-improving AI agent with tool-calling and 50+ integrations by Nous Research.

The stack runs the Hermes runtime in a sidecar container:
- Dashboard web UI on port 9119
- Messaging gateway for Telegram, Discord, Slack, etc.

The official image uses s6-overlay which requires root, so the devfile bypasses it with a `command`/`args` override that sets up the environment and starts the dashboard directly.

The editor (VS Code, ttyd, etc.) is chosen separately in the dashboard and injected into the `tools` container.

# Related Issue(s)

N/A

# Acceptance Criteria
<!-- _Check the relevant boxes below_ -->
- [x] Contributing guide

_Have you read the [devfile registry contributing guide](https://github.com/devfile/registry/blob/main/CONTRIBUTING.md) and followed its instructions?_
- [x] Test automation

_Does this repository's tests pass with your changes?_
- [ ] Documentation

_Does any documentation need to be updated with your changes?_
- [x] Check Tools Provider

_Have you tested the changes with existing tools, i.e. Odo, Che, Console? (See [devfile registry contributing guide](https://github.com/devfile/registry/blob/main/CONTRIBUTING.md) on how to test changes)_


# Tests Performed

- Schema validation passed locally (`bash tests/validate_devfile_schemas.sh`)
- `odo init` passed locally with odo v3.16.1
- Started a workspace from the Hermes sample on an OpenShift cluster (CRC, both amd64 and arm64)
- Verified the dashboard is accessible on port 9119
- Ran `hermes setup`, `hermes status`, and `hermes doctor` from the terminal
- Tested `restart-dashboard` command
- Confirmed config persists across workspace restarts (PVC at `/opt/data`)

# How To Test

1. Build a custom devfile registry image with this change
2. Deploy it to a Che/DevSpaces cluster
3. Create a workspace from the Hermes sample
4. Open the dashboard endpoint and run `hermes setup` to configure your API key
5. Verify the dashboard and agent commands work

# Notes To Reviewer

- The official image's s6-overlay entrypoint requires root, which is incompatible with OpenShift's arbitrary UID. The `command`/`args` override injects `/etc/passwd` for `whoami`, activates the venv, seeds config on first boot, and starts the dashboard with `--insecure` flag
- The dashboard starts with `--insecure` because there is no auth provider registered in the workspace context
- Uses `docker.io/nousresearch/hermes-agent:v2026.6.5` directly from DockerHub
- The endpoint uses `cookiesAuthEnabled: true` for authentication through the Che gateway
- No `starterProjects` - the sample is a standalone agent, not a code project