### PR TITLE
chore: update Konflux tekton patch schedule to weekends

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -37,12 +37,12 @@
       "commitMessageTopic": "{{depName}}"
     },
     {
-      "description": "Schedule Konflux tekton task updates Tuesday and Thursday nights (7 PM - 2 AM)",
+      "description": "Schedule Konflux tekton task updates Saturdays after 5 AM",
       "matchManagers": [
         "tekton"
       ],
       "schedule": [
-        "* 19-23,0-2 * * 2,4"
+        "* 5-23 * * 6"
       ]
     }
   ],


### PR DESCRIPTION
# Description of Changes

The [Konflux Documentation](https://konflux-ci.dev/docs/mintmaker/user/#scheduling) states that the Konflux patching only happens on Saturdays after 5AM. Given this seems to be enforced, we'll need to update our Konflux patching schedule across our Devfile Registry repositories to run MintMaker Renovate to patch Konflux on that schedule.

# Related Issue(s)

https://github.com/devfile/api/issues/1779

# Acceptance Criteria
<!-- _Check the relevant boxes below_ -->
- [ ] Contributing guide

_Have you read the [devfile registry contributing guide](https://github.com/devfile/registry/blob/main/CONTRIBUTING.md) and followed its instructions?_
- [ ] Test automation

_Does this repository's tests pass with your changes?_
- [ ] Documentation

_Does any documentation need to be updated with your changes?_
- [ ] Check Tools Provider

_Have you tested the changes with existing tools, i.e. Odo, Che, Console? (See [devfile registry contributing guide](https://github.com/devfile/registry/blob/main/CONTRIBUTING.md) on how to test changes)_


# Tests Performed
_Explain what tests you personally ran to ensure the changes are functioning as expected._

# How To Test
_Instructions for the reviewer on how to test your changes._

# Notes To Reviewer
_Any notes you would like to include for the reviewer._