### PR TITLE
feat: add OpenClaw AI assistant stack

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -59,3 +59,6 @@
 
 # Hermes stacks
 /stacks/hermes/ @akurinnoy
+
+# OpenClaw stacks
+/stacks/openclaw/ @akurinnoy

--- a/stacks/openclaw/1.0.0/devfile.yaml
+++ b/stacks/openclaw/1.0.0/devfile.yaml
@@ -1,0 +1,151 @@
+# OpenClaw — Personal AI Assistant Stack
+#
+# OpenClaw is a multi-channel AI assistant gateway by the OpenClaw project.
+# Repo: https://github.com/openclaw/openclaw
+#
+# The openclaw container runs the Gateway service which provides:
+#   - Control UI on port 18789
+#   - Multi-channel messaging (WhatsApp, Telegram, Slack, Discord, 25+ channels)
+#   - Agent tools, skills, cron jobs, webhooks
+#
+# State is relocated to /opt/data via OPENCLAW_CONFIG_DIR to handle
+# OpenShift arbitrary UIDs (the official image uses uid 1000 with 700 perms).
+#
+# First boot: run `openclaw setup` in the terminal to configure
+# your API key and model provider.
+
+schemaVersion: 2.2.2
+metadata:
+  name: openclaw
+  displayName: OpenClaw AI Assistant
+  description: Personal AI assistant with multi-channel messaging gateway. WhatsApp, Telegram, Slack, Discord, and 25+ channels.
+  icon: https://raw.githubusercontent.com/openclaw/openclaw/main/ui/public/favicon.svg
+  tags:
+    - AI
+    - Assistant
+    - Gateway
+    - OpenClaw
+  projectType: AI
+  language: TypeScript
+  version: 1.0.0
+
+attributes:
+  controller.devfile.io/storage-type: per-workspace
+
+components:
+  - name: tools
+    container:
+      image: quay.io/devfile/universal-developer-image:ubi9-latest
+      memoryLimit: 1Gi
+      memoryRequest: 256Mi
+      mountSources: true
+
+  # OpenClaw Gateway container.
+  # Runs the gateway service with Control UI on port 18789.
+  # State is relocated from /home/node/.openclaw (uid 1000, 700 perms)
+  # to /opt/data on a writable PVC for OpenShift arbitrary-UID compat.
+  - name: openclaw
+    container:
+      image: docker.io/openclaw/openclaw:2026.7.1
+      mountSources: false
+      memoryRequest: 2Gi
+      memoryLimit: 3Gi
+      env:
+        - name: HOME
+          value: /opt/data/home
+        - name: OPENCLAW_CONFIG_DIR
+          value: /opt/data/config
+        - name: OPENCLAW_WORKSPACE_DIR
+          value: /opt/data/config/workspace
+        - name: OPENCLAW_GATEWAY_BIND
+          value: lan
+        - name: OPENCLAW_SKIP_ONBOARDING
+          value: "1"
+      command: ["/bin/bash", "-c"]
+      args:
+        - |
+          if ! whoami &>/dev/null; then
+            echo "openclaw:x:$(id -u):0:OpenClaw:${HOME}:/bin/bash" >> /etc/passwd
+          fi
+
+          mkdir -p "${HOME}" "${OPENCLAW_CONFIG_DIR}" "${OPENCLAW_WORKSPACE_DIR}"
+
+          TOKEN_FILE="${OPENCLAW_CONFIG_DIR}/.gateway-token"
+          if [ ! -f "${TOKEN_FILE}" ]; then
+            TOKEN=$(head -c 32 /dev/urandom | base64 | tr -dc 'a-zA-Z0-9' | head -c 48)
+            echo "${TOKEN}" > "${TOKEN_FILE}"
+            chmod 600 "${TOKEN_FILE}"
+            echo "============================================"
+            echo "  Gateway token: ${TOKEN}"
+            echo "  Run 'show-token' command to see it again."
+            echo "============================================"
+          fi
+          export OPENCLAW_GATEWAY_TOKEN=$(cat "${TOKEN_FILE}")
+
+          exec tini -s -- node /app/openclaw.mjs gateway
+      endpoints:
+        - name: control-ui
+          targetPort: 18789
+          exposure: public
+          protocol: https
+          attributes:
+            cookiesAuthEnabled: true
+            discoverable: false
+            urlRewriteSupported: false
+      volumeMounts:
+        - name: openclaw-data
+          path: /opt/data
+
+  - name: openclaw-data
+    volume:
+      size: 10Gi
+
+commands:
+  - id: setup
+    exec:
+      label: "Configure OpenClaw (onboarding wizard)"
+      component: openclaw
+      commandLine: openclaw onboard
+      workingDir: /opt/data/config
+  - id: status
+    exec:
+      label: "Check gateway health"
+      component: openclaw
+      commandLine: |
+        echo "--- Health ---"
+        curl -fsS http://127.0.0.1:18789/healthz && echo " OK" || echo " FAIL"
+        echo "--- Readiness ---"
+        curl -fsS http://127.0.0.1:18789/readyz && echo " OK" || echo " FAIL"
+      workingDir: /opt/data/config
+  - id: show-token
+    exec:
+      label: "Display gateway access token"
+      component: openclaw
+      commandLine: cat "${OPENCLAW_CONFIG_DIR}/.gateway-token"
+      workingDir: /opt/data/config
+  - id: doctor
+    exec:
+      label: "Run diagnostics"
+      component: openclaw
+      commandLine: |
+        echo "=== Environment ==="
+        echo "HOME=${HOME}"
+        echo "OPENCLAW_CONFIG_DIR=${OPENCLAW_CONFIG_DIR}"
+        echo "UID=$(id -u) GID=$(id -g) Groups=$(id -G)"
+        echo ""
+        echo "=== Directory Permissions ==="
+        ls -la /opt/data/ 2>/dev/null
+        ls -la "${OPENCLAW_CONFIG_DIR}/" 2>/dev/null
+        echo ""
+        echo "=== Gateway Health ==="
+        curl -fsS http://127.0.0.1:18789/healthz 2>&1 || echo "Gateway not responding"
+        echo ""
+        echo "=== Token ==="
+        [ -f "${OPENCLAW_CONFIG_DIR}/.gateway-token" ] && echo "Token file exists" || echo "Token file MISSING"
+      workingDir: /opt/data/config
+  - id: restart-gateway
+    exec:
+      label: "Restart gateway process"
+      component: openclaw
+      commandLine: kill -TERM 1
+      workingDir: /opt/data/config

--- a/stacks/openclaw/1.0.0/devfile.yaml
+++ b/stacks/openclaw/1.0.0/devfile.yaml
@@ -82,6 +82,10 @@ components:
           fi
           export OPENCLAW_GATEWAY_TOKEN=$(cat "${TOKEN_FILE}")
 
+          openclaw config set gateway.mode local 2>/dev/null || true
+          openclaw config set gateway.controlUi.allowedOrigins '["*"]' 2>/dev/null || true
+          openclaw config set gateway.trustedProxies '["10.0.0.0/8","172.16.0.0/12","192.168.0.0/16"]' 2>/dev/null || true
+
           exec tini -s -- node /app/openclaw.mjs gateway
       endpoints:
         - name: control-ui
@@ -127,21 +131,7 @@ commands:
     exec:
       label: "Run diagnostics"
       component: openclaw
-      commandLine: |
-        echo "=== Environment ==="
-        echo "HOME=${HOME}"
-        echo "OPENCLAW_CONFIG_DIR=${OPENCLAW_CONFIG_DIR}"
-        echo "UID=$(id -u) GID=$(id -g) Groups=$(id -G)"
-        echo ""
-        echo "=== Directory Permissions ==="
-        ls -la /opt/data/ 2>/dev/null
-        ls -la "${OPENCLAW_CONFIG_DIR}/" 2>/dev/null
-        echo ""
-        echo "=== Gateway Health ==="
-        curl -fsS http://127.0.0.1:18789/healthz 2>&1 || echo "Gateway not responding"
-        echo ""
-        echo "=== Token ==="
-        [ -f "${OPENCLAW_CONFIG_DIR}/.gateway-token" ] && echo "Token file exists" || echo "Token file MISSING"
+      commandLine: openclaw doctor
       workingDir: /opt/data/config
   - id: restart-gateway
     exec:

--- a/stacks/openclaw/1.0.0/devfile.yaml
+++ b/stacks/openclaw/1.0.0/devfile.yaml
@@ -72,7 +72,7 @@ components:
 
           TOKEN_FILE="${OPENCLAW_CONFIG_DIR}/.gateway-token"
           if [ ! -f "${TOKEN_FILE}" ]; then
-            TOKEN=$(head -c 32 /dev/urandom | base64 | tr -dc 'a-zA-Z0-9' | head -c 48)
+            TOKEN=$(head -c 48 /dev/urandom | base64 | tr -dc 'a-zA-Z0-9' | head -c 48)
             echo "${TOKEN}" > "${TOKEN_FILE}"
             chmod 600 "${TOKEN_FILE}"
             echo "============================================"
@@ -137,5 +137,5 @@ commands:
     exec:
       label: "Restart gateway process"
       component: openclaw
-      commandLine: kill -TERM 1
+      commandLine: openclaw gateway stop 2>/dev/null; openclaw gateway
       workingDir: /opt/data/config

--- a/stacks/openclaw/1.0.0/devfile.yaml
+++ b/stacks/openclaw/1.0.0/devfile.yaml
@@ -14,7 +14,7 @@
 # First boot: run `openclaw setup` in the terminal to configure
 # your API key and model provider.
 
-schemaVersion: 2.2.2
+schemaVersion: 2.3.0
 metadata:
   name: openclaw
   displayName: OpenClaw AI Assistant

--- a/stacks/openclaw/stack.yaml
+++ b/stacks/openclaw/stack.yaml
@@ -1,0 +1,7 @@
+name: openclaw
+displayName: OpenClaw AI Assistant
+description: Personal AI assistant with multi-channel messaging gateway. WhatsApp, Telegram, Slack, Discord, and 25+ channels via a single Control UI.
+icon: https://raw.githubusercontent.com/openclaw/openclaw/main/ui/public/favicon.svg
+versions:
+  - version: 1.0.0
+    default: true

--- a/tests/check_odov3.sh
+++ b/tests/check_odov3.sh
@@ -74,6 +74,7 @@ ginkgo run --mod=readonly --procs 2 \
   --skip="stack: java-quarkus" \
   --skip="stack: ollama" \
   --skip="stack: hermes" \
+  --skip="stack: openclaw" \
   --slow-spec-threshold 120s \
   --timeout 3h \
   tests/odov3 -- -stacksPath "$stacksPath" -stackDirs "$stackDirs" ${args}


### PR DESCRIPTION
# Description of Changes

Adds an OpenClaw AI assistant stack to the devfile registry.

[OpenClaw](https://github.com/openclaw/openclaw) is a personal AI assistant that runs a Gateway service with a web Control UI and connects to 25+ messaging channels (WhatsApp, Telegram, Slack, Discord, etc.). TypeScript/Node.js, MIT license, 383K+ GitHub stars.

The stack follows the same two-container pattern as the existing AI agent stacks (`hermes`, `picoclaw`, `zeroclaw`):
- `tools` container - universal developer image for editor/terminal
- `openclaw` container - runs the Gateway service on port 18789

**Key design decisions:**
- State relocated to `/opt/data` via `OPENCLAW_CONFIG_DIR` to handle OpenShift arbitrary UIDs (the official image uses uid 1000 with 700-permission dirs)
- Gateway token auto-generated on first boot, persisted to PVC
- `gateway.trustedProxies` set to RFC 1918 ranges so connections through the cluster network are treated as local
- `cookiesAuthEnabled: true` on the Control UI endpoint
- Skipped in odo v3 tests - the gateway requires token setup before responding

**First boot flow:**
1. Open the Control UI endpoint
2. Run `show-token` command in the terminal to get the gateway token
3. Paste the token and click Connect
4. Approve device pairing (one-time per browser)
5. Run `setup` command to configure API keys and model provider

# Related Issue(s)

None

# Acceptance Criteria

- [x] Contributing guide

_Read the contributing guide and followed the stack structure conventions._

- [x] Test automation

_Schema validation passes. Stack skipped in odo v3 tests - the gateway requires onboarding before it can serve health checks within the 3-minute timeout._

- [ ] Documentation

_No documentation updates needed._

- [x] Check Tools Provider

_Tested on CRC cluster with Dev Spaces. Gateway boots, Control UI accessible, WebSocket connection works after token + device pairing._

# Tests Performed

1. Ran `bash tests/validate_devfile_schemas.sh` - all stacks pass including `openclaw`
2. Built the devfile registry image with the `openclaw` stack
3. Deployed to a CRC cluster running Dev Spaces
4. Created an `openclaw` DevWorkspace from the custom registry
5. Verified the gateway starts and reaches `ready` state
6. Accessed the Control UI via the endpoint route
7. Connected with the auto-generated gateway token

# How To Test

1. Build the devfile registry image:
   ```
   podman build -t devfile-registry:openclaw -f .ci/Dockerfile .
   ```
2. Deploy to a cluster with Dev Spaces and create a workspace using the `openclaw` stack
3. Open the Control UI endpoint in a browser
4. In the workspace terminal, run the `show-token` command to get the gateway token
5. Paste the token into the Control UI and click Connect
6. Approve device pairing when prompted
7. Verify the dashboard loads

# Notes To Reviewer

- Image `docker.io/openclaw/openclaw:2026.7.1` is the latest stable release, verified via `skopeo`
- The `gateway.auth.mode=none` approach was tested but OpenClaw refuses to bind to non-loopback without auth - this is by design
- Device pairing is a one-time approval per browser. There's no config to disable it, but it's a minor friction for a dev workspace
- Image mirroring to `quay.io` is deferred to a follow-up (same as `hermes`, `picoclaw`, `zeroclaw`)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added the OpenClaw AI assistant stack (version 1.0.0), including an OpenClaw gateway with a secure, public HTTPS control interface.
  - Enabled onboarding, health/readiness checks, diagnostics, token handling, and gateway restart workflows.
  - Configured persistent workspace and configuration storage with OpenShift-friendly arbitrary-UID support.
- **Chores / Maintenance**
  - Updated code ownership rules for the OpenClaw stacks directory.
- **Tests**
  - Excluded the OpenClaw stack from the ODOV3 Ginkgo test matrix.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->