### PR TITLE
fix: add starterProjects to AI stacks for command palette visibility

### DIFF
--- a/stacks/hermes/1.0.0/devfile.yaml
+++ b/stacks/hermes/1.0.0/devfile.yaml
@@ -32,6 +32,12 @@ metadata:
 attributes:
   controller.devfile.io/storage-type: per-workspace
 
+starterProjects:
+  - name: hermes-agent
+    git:
+      remotes:
+        origin: https://github.com/che-incubator/hermes-placeholder.git
+
 components:
   - name: tools
     container:

--- a/stacks/openclaw/1.0.0/devfile.yaml
+++ b/stacks/openclaw/1.0.0/devfile.yaml
@@ -32,6 +32,12 @@ metadata:
 attributes:
   controller.devfile.io/storage-type: per-workspace
 
+starterProjects:
+  - name: openclaw
+    git:
+      remotes:
+        origin: https://github.com/che-incubator/openclaw-placeholder.git
+
 components:
   - name: tools
     container:

--- a/stacks/picoclaw/1.0.0/devfile.yaml
+++ b/stacks/picoclaw/1.0.0/devfile.yaml
@@ -31,6 +31,12 @@ metadata:
 attributes:
   controller.devfile.io/storage-type: per-workspace
 
+starterProjects:
+  - name: picoclaw
+    git:
+      remotes:
+        origin: https://github.com/sipeed/picoclaw.git
+
 components:
   - name: tools
     container:

--- a/stacks/zeroclaw/1.0.0/devfile.yaml
+++ b/stacks/zeroclaw/1.0.0/devfile.yaml
@@ -30,6 +30,12 @@ metadata:
 attributes:
   controller.devfile.io/storage-type: per-workspace
 
+starterProjects:
+  - name: zeroclaw
+    git:
+      remotes:
+        origin: https://github.com/zeroclaw-labs/zeroclaw.git
+
 components:
   - name: tools
     container:


### PR DESCRIPTION
# Description of Changes

Add `starterProjects` section to picoclaw, zeroclaw, openclaw, and hermes devfiles. This works around eclipse-che/che#23479 — devfile commands are unavailable in the Che command palette when a workspace has no `starterProjects` section.

| Stack | Starter project | Notes |
|-------|----------------|-------|
| picoclaw | https://github.com/sipeed/picoclaw.git | Upstream repo (~40 MB) |
| zeroclaw | https://github.com/zeroclaw-labs/zeroclaw.git | Upstream repo (~160 MB) |
| openclaw | https://github.com/che-incubator/openclaw-placeholder.git | Placeholder — upstream is ~2.3 GB, times out during clone |
| hermes | https://github.com/che-incubator/hermes-placeholder.git | Placeholder — upstream is ~617 MB, unreliable clone |

Openclaw and hermes use lightweight placeholder repos because their upstream repositories are too large for the DevWorkspace project-clone init container to complete within the default 300s startup timeout.

# Related Issue(s)

- https://github.com/eclipse-che/che/issues/23479

# Acceptance Criteria

- [x] Contributing guide
- [x] Test automation
- [ ] Documentation
- [x] Check Tools Provider

# Tests Performed

- Deployed modified registry to CRC cluster (OpenShift, Dev Spaces)
- Created workspaces from all four AI stacks (picoclaw, zeroclaw, openclaw, hermes)
- Confirmed devfile commands appear in the Che command palette and execute correctly
- Verified openclaw and hermes start quickly with placeholder repos

# How To Test

1. Build and deploy the registry with these changes
2. Create a workspace from any of the four AI stacks (picoclaw, zeroclaw, openclaw, hermes)
3. Open the Che command palette — devfile commands should be listed and runnable

# Notes To Reviewer

- Minimal change — only adds a `starterProjects` block between `attributes` and `components` in each devfile
- Placeholder repos ([openclaw-placeholder](https://github.com/che-incubator/openclaw-placeholder), [hermes-placeholder](https://github.com/che-incubator/hermes-placeholder)) should be retired once eclipse-che/che#23479 is resolved

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added starter project templates for Hermes Agent, OpenClaw, PicoClaw, and ZeroClaw.
  * New workspaces can be initialized directly from each project’s Git repository.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->